### PR TITLE
Github API rate optimization

### DIFF
--- a/.github/workflows/run-in-container.yaml
+++ b/.github/workflows/run-in-container.yaml
@@ -33,7 +33,7 @@ jobs:
       CEPH_KEY_ID: ${{ github.event.client_payload.AWS_ACCESS_KEY_ID  || secrets.AWS_ACCESS_KEY_ID }}
       CEPH_SECRET_KEY: ${{ github.event.client_payload.AWS_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
 
-      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN || secrets.ACCESS_TOKEN}}
+      GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
       
       REMOTE: 1
 

--- a/02_notebook_executed.ipynb
+++ b/02_notebook_executed.ipynb
@@ -27,10 +27,10 @@
    "id": "dfe11a56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:14.761450Z",
-     "iopub.status.busy": "2022-11-17T11:42:14.761183Z",
-     "iopub.status.idle": "2022-11-17T11:42:16.355649Z",
-     "shell.execute_reply": "2022-11-17T11:42:16.354920Z"
+     "iopub.execute_input": "2022-11-18T20:10:05.958920Z",
+     "iopub.status.busy": "2022-11-18T20:10:05.958510Z",
+     "iopub.status.idle": "2022-11-18T20:10:07.268496Z",
+     "shell.execute_reply": "2022-11-18T20:10:07.267961Z"
     }
    },
    "outputs": [],
@@ -70,10 +70,10 @@
    "id": "9476e951",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:16.359301Z",
-     "iopub.status.busy": "2022-11-17T11:42:16.358700Z",
-     "iopub.status.idle": "2022-11-17T11:42:16.370725Z",
-     "shell.execute_reply": "2022-11-17T11:42:16.370156Z"
+     "iopub.execute_input": "2022-11-18T20:10:07.271060Z",
+     "iopub.status.busy": "2022-11-18T20:10:07.270793Z",
+     "iopub.status.idle": "2022-11-18T20:10:07.280329Z",
+     "shell.execute_reply": "2022-11-18T20:10:07.279875Z"
     }
    },
    "outputs": [
@@ -99,10 +99,10 @@
    "id": "9bc3a2c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:16.373499Z",
-     "iopub.status.busy": "2022-11-17T11:42:16.373269Z",
-     "iopub.status.idle": "2022-11-17T11:42:16.378557Z",
-     "shell.execute_reply": "2022-11-17T11:42:16.378009Z"
+     "iopub.execute_input": "2022-11-18T20:10:07.282413Z",
+     "iopub.status.busy": "2022-11-18T20:10:07.282052Z",
+     "iopub.status.idle": "2022-11-18T20:10:07.286119Z",
+     "shell.execute_reply": "2022-11-18T20:10:07.285690Z"
     }
    },
    "outputs": [],
@@ -133,10 +133,10 @@
    "id": "38f32d2b-22dc-419b-b76a-ce41e35ef58e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:16.381180Z",
-     "iopub.status.busy": "2022-11-17T11:42:16.380958Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.270589Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.269949Z"
+     "iopub.execute_input": "2022-11-18T20:10:07.288196Z",
+     "iopub.status.busy": "2022-11-18T20:10:07.287835Z",
+     "iopub.status.idle": "2022-11-18T20:10:24.969781Z",
+     "shell.execute_reply": "2022-11-18T20:10:24.969233Z"
     }
    },
    "outputs": [],
@@ -167,10 +167,10 @@
    "id": "115b9040-4b29-4445-b34a-3c1183707464",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.274327Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.273774Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.295629Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.295069Z"
+     "iopub.execute_input": "2022-11-18T20:10:24.972280Z",
+     "iopub.status.busy": "2022-11-18T20:10:24.972112Z",
+     "iopub.status.idle": "2022-11-18T20:10:24.989233Z",
+     "shell.execute_reply": "2022-11-18T20:10:24.988745Z"
     }
    },
    "outputs": [
@@ -405,28 +405,28 @@
    "id": "d02d7136-2bb4-4ec8-903c-315afb22c524",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.299541Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.298334Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.690841Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.690224Z"
+     "iopub.execute_input": "2022-11-18T20:10:24.991393Z",
+     "iopub.status.busy": "2022-11-18T20:10:24.991237Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.373731Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.373214Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'ResponseMetadata': {'RequestId': 'lal06l3f-d31ebj-7as',\n",
-       "  'HostId': 'lal06l3f-d31ebj-7as',\n",
+       "{'ResponseMetadata': {'RequestId': 'lamxr9ts-7qr0en-mr3',\n",
+       "  'HostId': 'lamxr9ts-7qr0en-mr3',\n",
        "  'HTTPStatusCode': 200,\n",
-       "  'HTTPHeaders': {'x-amz-request-id': 'lal06l3f-d31ebj-7as',\n",
-       "   'x-amz-id-2': 'lal06l3f-d31ebj-7as',\n",
+       "  'HTTPHeaders': {'x-amz-request-id': 'lamxr9ts-7qr0en-mr3',\n",
+       "   'x-amz-id-2': 'lamxr9ts-7qr0en-mr3',\n",
        "   'access-control-allow-origin': '*',\n",
        "   'access-control-allow-credentials': 'true',\n",
        "   'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',\n",
        "   'access-control-allow-headers': 'Content-Type,Content-MD5,Authorization,X-Amz-User-Agent,X-Amz-Date,ETag,X-Amz-Content-Sha256',\n",
        "   'access-control-expose-headers': 'ETag,X-Amz-Version-Id',\n",
        "   'etag': '\"6ba47dce636f84399bc487a224bfd5d5\"',\n",
-       "   'date': 'Thu, 17 Nov 2022 11:42:46 GMT',\n",
+       "   'date': 'Fri, 18 Nov 2022 20:10:25 GMT',\n",
        "   'keep-alive': 'timeout=5',\n",
        "   'content-length': '0',\n",
        "   'set-cookie': '1a4aa612fe797ac8466d7ee00e5520d5=a26d7dd2bae782e2ad6181b7887b5ff1; path=/; HttpOnly; Secure; SameSite=None'},\n",
@@ -449,10 +449,10 @@
    "id": "4d1b0d9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.694921Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.693612Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.884701Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.884094Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.375933Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.375766Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.662545Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.661981Z"
     }
    },
    "outputs": [
@@ -475,10 +475,10 @@
    "id": "70c24185-4fbf-4287-98fd-c8d721ef71fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.887840Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.887606Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.908807Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.908213Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.665275Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.664875Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.683735Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.683266Z"
     }
    },
    "outputs": [
@@ -713,10 +713,10 @@
    "id": "13dc895b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.911751Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.911515Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.917534Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.916989Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.685800Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.685645Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.690278Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.689810Z"
     }
    },
    "outputs": [
@@ -761,10 +761,10 @@
    "id": "d67035e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.920329Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.920112Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.925360Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.924820Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.692359Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.692209Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.696310Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.695868Z"
     }
    },
    "outputs": [],
@@ -781,10 +781,10 @@
    "id": "fddf9750-49f5-4997-8280-e94e1e778ad9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.927832Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.927621Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.932827Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.932251Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.698584Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.698232Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.703760Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.703347Z"
     }
    },
    "outputs": [
@@ -830,10 +830,10 @@
    "id": "b8cc628b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.935933Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.935727Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.942932Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.942361Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.706165Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.705818Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.712842Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.712422Z"
     },
     "tags": []
    },
@@ -897,10 +897,10 @@
    "id": "192aeb22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.945976Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.945758Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.952461Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.951845Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.715695Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.714864Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.721689Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.721259Z"
     },
     "tags": []
    },
@@ -945,10 +945,10 @@
    "id": "44e09f11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.956182Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.955957Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.962529Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.961917Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.724009Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.723639Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.730231Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.729814Z"
     },
     "tags": []
    },
@@ -1001,10 +1001,10 @@
    "id": "0ca35bc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.965566Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.965352Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.971801Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.971209Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.732830Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.732602Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.738840Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.738429Z"
     }
    },
    "outputs": [
@@ -1044,10 +1044,10 @@
    "id": "7b36d5d4-ec27-4a59-b63f-515830da1ae9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.974805Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.974599Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.977323Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.976719Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.741078Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.740853Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.743974Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.743554Z"
     }
    },
    "outputs": [],
@@ -1061,10 +1061,10 @@
    "id": "acc2bfd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.979896Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.979691Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.984987Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.984387Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.746693Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.745872Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.751612Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.751198Z"
     }
    },
    "outputs": [
@@ -1118,10 +1118,10 @@
    "id": "212f8a44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.988100Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.987878Z",
-     "iopub.status.idle": "2022-11-17T11:42:46.993156Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.992522Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.754582Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.753734Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.758946Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.758533Z"
     }
    },
    "outputs": [],
@@ -1136,10 +1136,10 @@
    "id": "c62d9484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:46.995671Z",
-     "iopub.status.busy": "2022-11-17T11:42:46.995462Z",
-     "iopub.status.idle": "2022-11-17T11:42:47.000414Z",
-     "shell.execute_reply": "2022-11-17T11:42:46.999810Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.761233Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.760911Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.766060Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.765641Z"
     }
    },
    "outputs": [
@@ -1185,10 +1185,10 @@
    "id": "cbc553ee-3e0b-45ed-83f6-02ae860bef85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:47.003451Z",
-     "iopub.status.busy": "2022-11-17T11:42:47.003235Z",
-     "iopub.status.idle": "2022-11-17T11:42:47.007212Z",
-     "shell.execute_reply": "2022-11-17T11:42:47.006630Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.768343Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.767976Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.771238Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.770790Z"
     }
    },
    "outputs": [
@@ -1213,10 +1213,10 @@
    "id": "709b4cf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:47.010193Z",
-     "iopub.status.busy": "2022-11-17T11:42:47.009987Z",
-     "iopub.status.idle": "2022-11-17T11:42:47.014711Z",
-     "shell.execute_reply": "2022-11-17T11:42:47.014171Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.773136Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.772983Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.777824Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.777416Z"
     }
    },
    "outputs": [],
@@ -1241,10 +1241,10 @@
    "id": "020f050a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:47.017273Z",
-     "iopub.status.busy": "2022-11-17T11:42:47.017066Z",
-     "iopub.status.idle": "2022-11-17T11:42:47.024401Z",
-     "shell.execute_reply": "2022-11-17T11:42:47.023775Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.779885Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.779731Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.787005Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.786581Z"
     }
    },
    "outputs": [
@@ -1291,10 +1291,10 @@
    "id": "2ecc397e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:47.027345Z",
-     "iopub.status.busy": "2022-11-17T11:42:47.027134Z",
-     "iopub.status.idle": "2022-11-17T11:42:47.034654Z",
-     "shell.execute_reply": "2022-11-17T11:42:47.034084Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.788933Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.788781Z",
+     "iopub.status.idle": "2022-11-18T20:10:25.795649Z",
+     "shell.execute_reply": "2022-11-18T20:10:25.795234Z"
     }
    },
    "outputs": [],
@@ -1326,10 +1326,10 @@
    "id": "65279268",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:47.037247Z",
-     "iopub.status.busy": "2022-11-17T11:42:47.037035Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.876122Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.875494Z"
+     "iopub.execute_input": "2022-11-18T20:10:25.797616Z",
+     "iopub.status.busy": "2022-11-18T20:10:25.797464Z",
+     "iopub.status.idle": "2022-11-18T20:10:27.985111Z",
+     "shell.execute_reply": "2022-11-18T20:10:27.984613Z"
     }
    },
    "outputs": [
@@ -1337,727 +1337,727 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/456 [00:00<?, ?it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "  0%|          | 0/456 [00:00<?, ?it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 21%|██▏       | 97/456 [00:00<00:00, 437.71it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 21%|██▏       | 97/456 [00:00<00:00, 517.43it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 31%|███       | 141/456 [00:00<00:01, 237.55it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 33%|███▎      | 149/456 [00:00<00:01, 288.43it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 37%|███▋      | 168/456 [00:00<00:01, 203.05it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 40%|███▉      | 182/456 [00:00<00:01, 250.85it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 41%|████▏     | 189/456 [00:00<00:01, 185.44it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 46%|████▌     | 208/456 [00:01<00:01, 173.55it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 46%|████▌     | 209/456 [00:00<00:01, 231.76it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 49%|████▉     | 225/456 [00:01<00:01, 165.25it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 51%|█████     | 233/456 [00:00<00:01, 217.88it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 53%|█████▎    | 241/456 [00:01<00:01, 158.67it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 56%|█████▌    | 255/456 [00:01<00:00, 208.90it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 56%|█████▋    | 257/456 [00:01<00:01, 153.97it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 60%|█████▉    | 272/456 [00:01<00:01, 150.34it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 61%|██████    | 276/456 [00:01<00:00, 203.03it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 63%|██████▎   | 287/456 [00:01<00:01, 147.56it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 65%|██████▍   | 296/456 [00:01<00:00, 189.11it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 66%|██████▌   | 302/456 [00:01<00:01, 145.40it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 69%|██████▉   | 315/456 [00:01<00:00, 188.54it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 70%|██████▉   | 317/456 [00:01<00:00, 143.80it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 73%|███████▎  | 332/456 [00:01<00:00, 127.69it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 73%|███████▎  | 334/456 [00:01<00:00, 187.15it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 76%|███████▌  | 346/456 [00:02<00:00, 130.71it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 77%|███████▋  | 353/456 [00:01<00:00, 186.67it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 79%|███████▉  | 360/456 [00:02<00:00, 132.51it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 82%|████████▏ | 372/456 [00:01<00:00, 185.64it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 82%|████████▏ | 374/456 [00:02<00:00, 133.85it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 85%|████████▌ | 388/456 [00:02<00:00, 135.01it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 86%|████████▌ | 391/456 [00:01<00:00, 182.97it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 88%|████████▊ | 402/456 [00:02<00:00, 136.10it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 90%|████████▉ | 410/456 [00:01<00:00, 176.77it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 91%|█████████ | 416/456 [00:02<00:00, 136.67it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 94%|█████████▍| 428/456 [00:02<00:00, 174.80it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 94%|█████████▍| 430/456 [00:02<00:00, 137.57it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      " 97%|█████████▋| 444/456 [00:02<00:00, 137.99it/s]/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      " 98%|█████████▊| 446/456 [00:02<00:00, 173.64it/s]/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "/tmp/ipykernel_141/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+      "/tmp/ipykernel_142/4191214648.py:3: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
       "  pr_df[f\"title_wordcount_{word}\"] = preproc_titles.apply(\n",
-      "100%|██████████| 456/456 [00:02<00:00, 161.09it/s]\n"
+      "100%|██████████| 456/456 [00:02<00:00, 208.99it/s]\n"
      ]
     }
    ],
@@ -2075,10 +2075,10 @@
    "id": "41cf9f16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.879167Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.878635Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.891734Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.891170Z"
+     "iopub.execute_input": "2022-11-18T20:10:27.987651Z",
+     "iopub.status.busy": "2022-11-18T20:10:27.987404Z",
+     "iopub.status.idle": "2022-11-18T20:10:27.997863Z",
+     "shell.execute_reply": "2022-11-18T20:10:27.997397Z"
     }
    },
    "outputs": [],
@@ -2109,10 +2109,10 @@
    "id": "b6db783b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.895278Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.894761Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.904310Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.903691Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.000379Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.000011Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.008170Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.007739Z"
     }
    },
    "outputs": [],
@@ -2140,10 +2140,10 @@
    "id": "f6cb1704",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.907019Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.906673Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.922773Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.922166Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.010227Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.010065Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.023860Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.023410Z"
     }
    },
    "outputs": [
@@ -2301,10 +2301,10 @@
    "id": "b5687644",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.925541Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.925199Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.930693Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.930117Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.026000Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.025838Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.031847Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.031392Z"
     }
    },
    "outputs": [
@@ -2369,10 +2369,10 @@
    "id": "ea080575",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.933816Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.933254Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.939360Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.938773Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.034021Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.033867Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.039961Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.039546Z"
     }
    },
    "outputs": [
@@ -2408,10 +2408,10 @@
    "id": "ba70b93f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.942031Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.941703Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.946016Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.945404Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.041868Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.041709Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.046061Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.045609Z"
     }
    },
    "outputs": [],
@@ -2444,10 +2444,10 @@
    "id": "2e00c415",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.948554Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.948209Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.951225Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.950631Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.047940Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.047789Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.050116Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.049642Z"
     }
    },
    "outputs": [],
@@ -2462,10 +2462,10 @@
    "id": "36a1dcda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.953704Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.953361Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.977276Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.976458Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.052090Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.051939Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.071969Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.071550Z"
     }
    },
    "outputs": [],
@@ -2479,10 +2479,10 @@
    "id": "d7de1e91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.980362Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.979809Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.984115Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.983529Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.073871Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.073715Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.076206Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.075740Z"
     }
    },
    "outputs": [],
@@ -2496,10 +2496,10 @@
    "id": "17e5fd80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.987349Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.987021Z",
-     "iopub.status.idle": "2022-11-17T11:42:49.991213Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.990640Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.078119Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.077962Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.080583Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.080128Z"
     }
    },
    "outputs": [],
@@ -2515,10 +2515,10 @@
    "id": "25a14da8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:49.994628Z",
-     "iopub.status.busy": "2022-11-17T11:42:49.994301Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.000366Z",
-     "shell.execute_reply": "2022-11-17T11:42:49.999799Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.082534Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.082386Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.085770Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.085307Z"
     }
    },
    "outputs": [
@@ -2583,10 +2583,10 @@
    "id": "ecd11700",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.003347Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.003017Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.008167Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.007615Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.087995Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.087848Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.091169Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.090686Z"
     }
    },
    "outputs": [],
@@ -2615,10 +2615,10 @@
    "id": "cc0b7906",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.011308Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.010983Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.038078Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.037517Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.093067Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.092914Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.114712Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.114260Z"
     }
    },
    "outputs": [],
@@ -2634,10 +2634,10 @@
    "id": "4fe7bb1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.041094Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.040664Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.058567Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.058006Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.116708Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.116557Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.130010Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.129541Z"
     }
    },
    "outputs": [
@@ -2810,10 +2810,10 @@
    "id": "64e7a822",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.061883Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.061555Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.067069Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.066527Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.132542Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.132390Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.135843Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.135365Z"
     }
    },
    "outputs": [],
@@ -2852,10 +2852,10 @@
    "id": "b1a5adc0-e8e2-4159-af36-a6fdc938de17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.069702Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.069494Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.076155Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.075595Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.137851Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.137617Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.141727Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.141256Z"
     }
    },
    "outputs": [
@@ -2890,10 +2890,10 @@
    "id": "ec16152d-0fb3-4775-913a-9e476382d713",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.078767Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.078550Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.108782Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.108215Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.143929Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.143692Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.166091Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.165553Z"
     }
    },
    "outputs": [
@@ -2901,7 +2901,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_141/2436122750.py:9: SettingWithCopyWarning: \n",
+      "/tmp/ipykernel_142/2436122750.py:9: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -3090,10 +3090,10 @@
    "id": "e353c92b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.111866Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.111549Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.116023Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.115454Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.168537Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.168245Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.171288Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.170811Z"
     }
    },
    "outputs": [],
@@ -3115,10 +3115,10 @@
    "id": "986b3424-0401-4c7a-8f28-a860b87e14ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.118948Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.118633Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.122586Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.122026Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.173327Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.172969Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.175465Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.174996Z"
     }
    },
    "outputs": [],
@@ -3139,10 +3139,10 @@
    "id": "3e1d24a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.125211Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.124790Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.134197Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.133657Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.177376Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.177147Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.184685Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.184209Z"
     }
    },
    "outputs": [
@@ -3258,10 +3258,10 @@
    "id": "278e3073",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.136930Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.136437Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.141131Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.140591Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.186693Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.186458Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.189558Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.189093Z"
     }
    },
    "outputs": [],
@@ -3277,10 +3277,10 @@
    "id": "2df4fb8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.143484Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.143273Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.179039Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.178436Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.191693Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.191545Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.219425Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.218922Z"
     }
    },
    "outputs": [],
@@ -3295,10 +3295,10 @@
    "id": "418becb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.181922Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.181561Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.186545Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.185883Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.221463Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.221306Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.224255Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.223788Z"
     }
    },
    "outputs": [
@@ -3306,11 +3306,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Feature size: 0.000000\n",
-      "Feature created_at_day: 0.043683\n",
-      "Feature created_at_month: 0.130751\n",
-      "Feature created_at_weekday: 0.091846\n",
-      "Feature created_at_hour: 0.148193\n"
+      "Feature size: 0.036471\n",
+      "Feature created_at_day: 0.055111\n",
+      "Feature created_at_month: 0.131241\n",
+      "Feature created_at_weekday: 0.066010\n",
+      "Feature created_at_hour: 0.075849\n"
      ]
     }
    ],
@@ -3325,16 +3325,16 @@
    "id": "b08ea157",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.189551Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.189332Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.318386Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.317703Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.226632Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.226481Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.330256Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.329808Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZgAAAF6CAYAAAAkt07cAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAA9dUlEQVR4nO3debgcVZ3G8W8SSEASCISgBhJQIK+yCBNFRHFElEV2lVUgioCC7IuIKBBBFhkWQaPEsINGBBlcQHAYRYRBASHixo89CYQlhIDsS5L545wmlc69Sfe9Xd33dr+f58mT21XV1aerq+p39howf/58zMzMGm1gqxNgZmbtyQHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjB9iKTjJF3Q6nRYY0j6tqRnJD3Z6rSURdJmkh5r0L4kaaqkFyQd2oh9NpKk8yUd3+p09ISkFyW9uwfv69U9aUC7jIOR9CjwdmBuYfHYiJjZy33uFxE39S51/Y+kCcBaEbFXq9PSH0kaAwSwekQ83aB9zgdmAaMi4s28bGngcWBkRAyoYR9rAI8AS1f20cs0bQZcERGrLSbNa0fEgzXs60Lg3xFxRG/T1VuSvkC69jdtwmcNB84GtgGWA54ALoqI0/P6mo9h3v5m0m9SV2BY0m/ZE+1Wgtk+IoYW/vU4uDSCpKVa+fk91V/T3VuSBkhq1DUxBpjdk+CyhOM/B/hU4fWn8rJ2sDrwj568sZ+fs+cAQ4H3AisAOwA1BZO+rt1KMIuUNiStwILcwTzgYuDEiJgraU1gMrABMB+4ETgoIp6TdDmwJ/AaqVR0EnAHVRG++Lk5178e8CrpJDkSuKq7z+/iO0wglxoKOc0v5s8eCnwd+AtwIekGdkVEHJzf+wVgf+AeYG9SLuigiPjfvH4UcD6wKfAs8J2ImFz43GK6j8tpHpC//0MRsYGkfYBjgNVIOenvRMSkvI/NgCtIF8vX8jE7LiIuzuuXBb4N7AwMB/4GbBERr0j6UP68dYBpwGERcXP18cn7+RpwKLA8MBP4SkT8r6RB+XP3BVYB7gd2iogZkj4MnAuMzcsPi4j/y/u7GbgN2AwYB6wPLAV8D3h//p7HR8TP8vbbAGcCo4F/A+dExJlVafwk8CtgCPAycHVEfEHSDsBpwKrAVODAiPhXfs+jwA9J55yA5apLGDknezywQUTskpddTfrNv10pwVRfC1Xn1fSc9pfybrcAtqJQWq0u5dTyu9dSgsnpWId0nn0amA58PiLukvQ74GPAG8Cb+bd4Kv8On8rHcTJwakTMK5zvdwDj87FbLW/3LuCjwF+BzwLHAp/P+9sjIu7JaTs272MVYAbwjYj4b0nvzcd0aeAV4M2IGC7pEuCxiPhmfv/+pHNuJeBW4IBKpjZ/7wOBo4CRwI+BgyNikRuupL8D34yIa7tYd0v+Li+T7lH7Ar8FLgc2Jp2rt+XPfkzSKfn7Vo7jJRFxcNXvsMg5nI/fMyw4ZyFdL19i4XNjU+CM/Du+QLo2LqlOd0W7lWC6cgnpQK8F/AewJbBfXjeAdMGPIuUeRgMTACJib9IFUCkVnVHj5+0IXE26if54CZ9fi42BtYHdgO8C3wA+CawL7CrpY1XbPgSsDJwIXCNppbzup8Bj+bvuDJwqafNu0n0hcCpwZf7uG+Rtnga2I93c9wHOkTSusI93kHJgq5IuhImSVszrziTdsD9MuiCPAeZJWhW4jhR8VgKOBn4uaWT1gZAk4GBgo4gYRroxPppXHwnsQQrky5MC88v5+18HnAeMIAWy6ySNKOx6b9KFNIx0A/0f4CekG8/uwA8krZO3vRD4cv789YDfVacz39g/BczMx+8LksYCU4DDSTec64FfSRpceOsewLbA8MVUX10L/Kek4fnYfhT4RTfbduU/8//Dc9pur+E9S/rd67ED6VwcDvwS+D5ARGwO/JF0Ex4aEfeTgssKwLtJwWd8/vyKjYGHSVXjp+RluwLfJF0DrwG3A3fn11eTfv+Kh0jHbwXgW8AVkt6Zg/4BwO05LcOrv0S+dk7Ln/dOUsbop1WbbQdsBLwvb7dVN8fkT8ApkvaRtHZxRURUfq8NclquJN23LyaV+MaQgmDlOH6DhY/jwV183iLncES8xMLn7CI1QJJWB35D+l1GAhuSMkrd6s/Fyq5cK6lyYd4MfJl0wxkeEa8AL0k6h3QzmZTrNCtF0VmSzibdmHvj9kpORNLyi/v8Gvd3ckS8CvxW0kvAlEq1i6Q/koLWH/K2TwPfzbmkKyUdBWybc+kfAbbN+5qaG+7Gs+AG+Va6gVfSvXxhEXFd4eUfJP2WdIHenZe9AZyUb47XS3oxJVN3kG74H4qIx/O2lRLEXsD1EXF9Xv4/ku7Kx+3SqiTMJeWw1pE0KyIeLazbDzgmIiK//mve/97AAxFxeV4+JTcgb08K/pByef/I228NPFopeQH3SPo5sAvpJvRG/vy/RsQcaq+e2g24LiL+J3/OmcBhpIB7c97mvIiYsYT9vEoqHe1GyiD9Mi8rTQ2/ez1urfzWuZbg8K42yiXS3YENI+IF4AVJZ5EyAxfmzWZGxPfy32/mc/a/I+IveR//TSrhXpZfX0nKoFS+11WFj7xS0teBD1JbwN6T1E5yd97314E5ktYonJenR8RzwHOSfk+6Id/Qxb4OAY7IafuRpGnAIRHxm64+OCJmAz+vvM6llt/XkOaKnp7DnwNuiogp+fXs/K9b7RZgdipWkUn6IKmY+0ThhjmQVBxG0ttJVScfJeVeB9L7+uziDWL1xX1+jZ4q/P1KF6+HFl4/XlUEn0YqsYwCns0XanHdB7pJd5ckfYoUgMeSvsfbSFVdFbOrct4v5/StDCxDyjFWWx3YRdL2hWVL08UFk4v3h5NKmetKuhE4Mue0Rnez/1Gk71o0jVTKqqj+zTaW9Fxh2VKkKglIVS7fBE6XdC9wbI2lgIXSkat5ZiwmHYtzGSn3PIBURVOqGn73ehR71L0MLCNpqS5KbCuTzoPib7e4362i5utF0nhSyXeNvKhyrtZiFIUAGxEvSpqd0/doXlz9XYvX6lty5vNUUq3C8qQqrqskjYmIZ6u3l/Q2UrXW1kClhmCYpEFdVb13oafncHfXWLfaLcBUm0EqJq/cTZXDqaR6zfUj4llJO5GLmll1felLpIsLeCuXVV2VU3zPkj6/0VaVNKAQZMaQcrgzgZUkDSsEmTGk3kcV1d91odeShpByTeOBX0TEG5KuJd3kluQZUi57TXLJomAGcHlE7F/DfoiInwA/yRfiJOA7pFztjLz/v1e9ZSYpaBSNYeGcZPVv9oeI2KKbz78T2FGp99bBwM9IF96SzCS17wCpQ0F+3+J+g+78kVQtM59U979m1fqFzlNS1eXiPqPb7Xv5u/fGM6Sc9urAP/OyJZ2zNcvVPZOBT5BK73MlTWXB91rSvhc6ryQtR6qCfbzbd9QgIv4t6VRSe+u7SO2l1Y4itdNtHBFPStqQ1GZUU9oXcw4v6TvPIJXwatbWASYinsjF+bOU+q+/SPrRVouIP5BKLc8Dz+e2gK9W7eIpUv1vxf2kHNe2pIa240hVNj39/EZbBThU0g+AnUjtStdHxGxJ/wecJuloUk50X1IxvztPAVtIGhgR84DBpO86i1Qd8SlSe1L1DX0RObd+EXB2rrJ6inSi3k3qGHCnpK2Am0i51g8BD0bEQuMrchvMqqRGzVdJOdJBefUFwMmS/kmq9lyfdLFfD3xP0udIF9JnSQ2Uv+4mub8m5ez2ZkGd+oak3+4hUlXZryPieUn/JnXcqMXPgGMlfQK4hVQ99hq5qrAeETG/UuLLf1dvMhXYXdJvSB1YdmZBQJ2V0/xu0vlc2f5rSl2rnyfd3Cp6/Lv3Rr7h/4zUNjGe1D53JKktrxGWI91QZwEodWRYr7D+KWA1SYMj4vUu3j+FVN36E+BfpMzqn6uqbWuS7w03kDJfA0nnxnOkbu6VtLybBdX5w0jn/nNKbYzV1frV963iZw2m+3P4KWCEpBUi4vku3v5j4DhJuwLXkNquRkfE1O6+Wyc08o8nXST/JFV/XU3K/UGqUx9HuqiuIx20otOAb0p6TtLR+aB/hXQze5yU81vSILPFfX6j/ZnUIeAZUqPnzrm+FlID8hqknNd/k3qyLW58T6V+eraku3PJ51DSjXIOqT72l3Wk7WhStcqd5F5swMDc5rAjKVjPIuWSvkrX5+YQ4PT8/Z4kBdTKzfDsnLbfknrGXAgsm7//dqRc32xS54LtIuKZrhKZv+eWpPr/mflzvsOCjMTewKP5wjyAxQfp4n4D2IvUQPoMqQ1o+25uXrXs7x+VdqMuHE8q1cwhneM/KbzvZdK5cVs+rz+U24WuBO4l9VL8dWH73v7uvXEI6Rp7mFRS+wlwUSN2HBH/BM4idQJ4ipQhua2wye9IXaaflLTIuZKvneNJpbsnSMd79x4mZz6p0f4Z0jm3Bam99MW8fgJwaf69diV19lk2b/8nFm3XORfYWdIcSed18XldnsMRcR8pcD6cP2tU1XeeTmobPYp0DU8lZWC61TbdlDudmjgwzMysFp1QgjEzsxZwgDEzs1K4iszMzErhEoyZmZWirbspFwwhTdnwBAvPtmxmZt0bROr1eiepW31dOiXAbEQanGZmZvX7KKmreF06JcA8ATBnzkvMm+c2JzOzWgwcOIAVV1wO8j20Xp0SYOYCzJs33wHGzKx+PWpacCO/mZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlaKThkHY2bWECssvyyDh7TXrfP1197k+X+/0vD9ttdRMjMr2eAhS3HqN65udTIa6rhTdi5lv64iMzOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVomndlCWNBS4FRgCzgfER8UDVNlsCpwLrA9+LiKO72I+Ae4AfdLXezMz6hmaWYM4HJkbEWGAiMKmLbR4G9gP+q6sdSBqU33dtSWk0M7MGaUqAkbQKMA6YkhdNAcZJGlncLiIejIipwJvd7OpY4NfA/SUl1czMGqRZJZjRwOMRMRcg/z8zL6+JpA2ArYBzSkmhmZk1VL+YKkbS0sCPgH0iYm5qhqnfiBFDG5ouM7N2MXLksIbvs1kBZgawqqRBOUAMAkbl5bV4J7AmcH0OLsOBAZKWj4gv1ZqI2bNfZN68+fWl3MysoIwbcV8wa9YLiywbOHBArzLmTQkwEfG0pKnAHsAV+f97ImJWje+fDqxceS1pAjDUvcjMzPquZlaRHQBcKukEYA4wHkDS9cAJEXGXpE2BnwLLk0oouwP7RsSNTUynmZk1QNMCTETcB2zcxfJtCn/fCqxWw74mNDRxZmbWcB7Jb2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK0S8muzRrheVXGMKQwYNbnYyGeu311/n386+1OhnWIRxgzLoxZPBgvnDxYa1ORkNdss+5gAOMNYeryMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBxszMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFE0byS9pLHApMAKYDYyPiAeqttkSOBVYH/heRBxdWHc8sDswF3gDOC4ibmxS8s3MrE7NLMGcD0yMiLHARGBSF9s8DOwH/FcX6+4ANoqI9wFfBK6UtGxZiTUzs95pSoCRtAowDpiSF00BxkkaWdwuIh6MiKnAm9X7iIgbI+Ll/PJeYACpNGRmZn1Qs0owo4HHI2IuQP5/Zl7eE+OBhyLisQalz8zMGqzfzaYs6WPAycAW9b53xIihjU+QWT8zcuSwVifB+qAyzotmBZgZwKqSBkXEXEmDgFF5ec0kbQJcAewYEVFvImbPfpF58+bX+zbrUO16I54164VWJ6Ff66TzYuDAAb3KmDeliiwingamAnvkRXsA90TErFr3IWkj4Epg54i4u+GJNDOzhmpmFdkBwKWSTgDmkNpRkHQ9cEJE3CVpU+CnwPLAAEm7A/vm7sg/AJYFJkmq7HPviPhbE7+DmZnVqGkBJiLuAzbuYvk2hb9vBVbr5v0blZc6MzNrNI/kNzOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBRLNeuDJI0FLgVGALOB8RHxQNU2WwKnAusD34uIowvrBgHnAVsD84HTI+KCJiXfzMzq1MwSzPnAxIgYC0wEJnWxzcPAfsB/dbFuT2AtYG1gE2CCpDXKSaqZmfVWUwKMpFWAccCUvGgKME7SyOJ2EfFgREwF3uxiN7sBkyNiXkTMAq4Fdikt0WZm1ivNqiIbDTweEXMBImKupJl5+awa9zEGmFZ4PT2/v2YjRgytZ3OztjRy5LBWJ8H6oDLOi6a1wfQFs2e/yLx581udDOsn2vVGPGvWC61OQr/WSefFwIEDepUxb1YbzAxg1dxQX2mwH5WX12o6sHrh9Zg6329mZk3UlAATEU8DU4E98qI9gHtyW0qtrgL2lzQwt93sBFzdyHSamVnjNLOK7ADgUkknAHOA8QCSrgdOiIi7JG0K/BRYHhggaXdg34i4Ebgc2BiodG0+KSIeaWL6zcysDk0LMBFxHylAVC/fpvD3rcBq3bx/LnBgaQk0M7OG8kh+MzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpOmqqGDPrmeHDBrP0MkNanYyGeuPV13juhddbnYy25gBjZku09DJDuH78Pq1ORkNtc9nF4ABTqh5XkUlaVlJ7ZWnMzKxhag4wks6U9MH897bAs8AcSduXlTgzM+u/6inB7An8Pf99ArAXsAPpEcdmZmYLqacN5m0R8bKkEcC7I+LnAJJWX8L7zMysA9UTYO6XtCewFvA/AJJWBl4pI2FmZta/1RNgvgKcC7wBfDEv2wr4baMTZWZm/V/NASYi7gQ+XLXsx8CPG50oMzPr/+oaByNpC2B3YJWI2F7SB4DlI+J3paTOzMz6rXq6KR8C/JD0RMn/zItfAb5dQrrMzKyfq6eb8uHAJyPidGBeXnYfoEYnyszM+r96AswwYEb+e37+f2nAcy2Ymdki6mmDuQU4FjilsOxQ4Pe1vFnSWOBSYAQwGxgfEQ9UbTMIOA/YmhTETo+IC/K6VYCLgdGkwPZ74NCIeLOO72BmZk1STwnmEODTkh4FhkkKYFfgyBrffz4wMSLGAhOBSV1sUxlnszawCTBB0hp53XHAvyLifcD7gPcDn6kj/WZm1kQ1BRhJA4H3Ah8lBZXPAZ8HPhgRT9bw/lWAccCUvGgKME7SyKpNdwMmR8S8iJgFXAvsktfNJwW2gcAQYDDweC3pNzOz5qupiiwi5kn6RUQMA+7I/+oxGng8Iubm/c2VNDMvn1XYbgwwrfB6et4G4GTg58ATwHLA9yPitnoSMWLE0DqTbdZ+Ro4c1uok9Bk+FguUcSzqaoOR9KGI+FPDU1GbXYB7gU+QOhz8RtLOEXF1rTuYPftF5s2bv+QNzWjfm8+sWS/U/R4fiwU66VgMHDigVxnzegLMNNJN/Rek3mRv3akj4oQlvHcGsKqkQbn0MggYxYJeaRXTgdWBO/PrYonmEOCLETEPeD6n4+NAzQHGzMyap55G/mVJbSLzgdVIVVej89+LFRFPA1OBPfKiPYB7cjtL0VXA/pIG5vaZnVgQQB4h9S5D0mDgkyx4fICZmfUx9cxF1tvnpR4AXCrpBGAOMB5A0vXACRFxF3A5sDFptgCAkyLikfz34cD5kv4GDCJ1U57cyzSZmVlJ6p2LbG1S6WNVUg+uKdVjWboTEfeRgkf18m0Kf88FDuzm/Q8BW9STXjMza5165iLbHvgL8B7S45IF3CVph5LSZmZm/Vg9JZhTgR0j4q2R+5I2A74P/LLB6TIzs36unkb+1YA/Vi27lRoa+c3MrPPUE2CmAkdVLTsyLzczM1tIPVVkBwK/knQYafzKaOBlYPsyEmZmZv1bPd2U75P0XuBDpEGSM4E/R8QbZSXOzMz6r5oDjKQNgdkRcWth2WhJK0XEX8tInJmZ9V/1tMFcQXoOS9Fg0uBIMzOzhdQTYMZExMPFBXnw4xoNTZGZmbWFegLMY5LGFRfk1zMbmyQzM2sH9fQiOwf4haQzgIdIT548ioUfoWxmZgbU14tssqTngH1JgytnAEdGxM9LSpuZmfVjS6wik/R+SesBRMRVpFmQ7yVNeLmlJD8m0szMFlFLG8x3gXcUXv+IVD02CVgXOKPxyTIzs/6ulgDzXvIcZJKGA9sCe0XERNLU/R7Jb2Zmi6glwCwFvJ7//hDwRETcDxARM4Dh5STNzMz6s1oCzD+AXfLfuwM3VVZIWhV4voR0mZlZP1dLL7KvkSa5PB+YC2xaWLcbcFsZCTMzs/5tiSWYPPfYGNLjit8dEVFYfR1wRElpMzOzfqymcTAR8QLpccnVy6OLzbskaSxwKTACmA2Mj4gHqrYZBJwHbA3MB06PiAsK63cFjgcG5PWfjIinak2DmZk1Tz1TxfTW+cDEiBgLTCR1c662J6kL9NrAJsAESWsASPoAMAHYIiLWI1XVuf3HzKyPakqAkbQKMA6YkhdNAcZJGlm16W7A5IiYFxGzgGtZ0MHgCODMiHgSICKej4hXS0+8mZn1SD1zkfXGaODxiJgLEBFzJc3My2cVthsDTCu8np63AVgHeETSLcBQ4BrglIiYX2siRozwpANmI0cOa3US+gwfiwXKOBbNCjCNMAh4H6mzwWDgBlIAuqzWHcye/SLz5tUcj6zDtevNZ9asF+p+j4/FAp10LAYOHNCrjHmz2mBmAKvmRvxKY/6ovLxoOrB64fWYwjbTgasj4rXc6eAXwAdLTbWZmfVYUwJMRDwNTCVNLUP+/57czlJ0FbC/pIG5fWYn4Oq87iekyTUHSFoa+ATgRzWbmfVRzexFdgBwiKT7gUPyayRdn3uIQXr88sPAA8CfgJMi4pG87qfA08A/ScHqH8CFTUu9mZnVpWltMBFxH7BxF8u3Kfw9Fziwm/fPA47M/8zMrI9rZgnGzMw6iAOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK0XTnmhp/cOKKwxmqcFDWp2Mhnrz9deY8/zrrU6GWcdxgLGFLDV4CH85Y79WJ6Oh3n/MBYADjFmzNS3ASBoLXAqMAGYD4yPigaptBgHnAVsD84HTI+KCqm0E3AP8ICKObkbazcysfs1sgzkfmBgRY4GJwKQuttkTWAtYG9gEmCBpjcrKHIAmAdeWnVgzM+udpgQYSasA44ApedEUYJykkVWb7gZMjoh5ETGLFEh2Kaw/Fvg1cH+5KTYzs95qVhXZaODxiJgLEBFzJc3My2cVthsDTCu8np63QdIGwFbAx4Hje5KIESOG9uRt1gZGjhzW6iT0GT4WC/hYLFDGsegXjfySlgZ+BOyTg1OP9jN79ovMmze/oWlrN+16wc2a9ULd7/GxWMDHYoFOOhYDBw7oVca8WW0wM4BVcxtKpS1lVF5eNB1YvfB6TN7mncCawPWSHgUOB/aX9KNyk21mZj3VlBJMRDwtaSqwB3BF/v+e3M5SdBUpcFxD6m22E/DRiJgOrFzZSNIEYKh7kZmZ9V3N7EV2AHCIpPuBQ/JrJF0v6QN5m8uBh4EHgD8BJ0XEI01Mo5mZNUjT2mAi4j5g4y6Wb1P4ey5wYA37mtDQxJmZWcN5LjIzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBxszMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxKsVSzPkjSWOBSYAQwGxgfEQ9UbTMIOA/YGpgPnB4RF+R1xwO7A3OBN4DjIuLGZqXfzMzq08wSzPnAxIgYC0wEJnWxzZ7AWsDawCbABElr5HV3ABtFxPuALwJXSlq29FSbmVmPNCXASFoFGAdMyYumAOMkjazadDdgckTMi4hZwLXALgARcWNEvJy3uxcYQCoNmZlZH9SsKrLRwOMRMRcgIuZKmpmXzypsNwaYVng9PW9TbTzwUEQ8Vk8iRowYWleirX2MHDms1UnoM3wsFvCxWKCMY9G0NphGkfQx4GRgi3rfO3v2i8ybN7/xiWoj7XrBzZr1Qt3v8bFYwMdigU46FgMHDuhVxrxZbTAzgFVzI36lMX9UXl40HVi98HpMcRtJmwBXADtFRJSaYjMz65WmBJiIeBqYCuyRF+0B3JPbWYquAvaXNDC3z+wEXA0gaSPgSmDniLi7Gek2M7Oea2YV2QHApZJOAOaQ2lGQdD1wQkTcBVwObAxUui+fFBGP5L9/ACwLTJJU2efeEfG3JqXfzMzq0LQAExH3kYJH9fJtCn/PBQ7s5v0blZc6MzNrNI/kNzOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBRLNeuDJI0FLgVGALOB8RHxQNU2g4DzgK2B+cDpEXHBktaZmVnf08wSzPnAxIgYC0wEJnWxzZ7AWsDawCbABElr1LDOzMz6mKaUYCStAowDtsiLpgDflzQyImYVNt0NmBwR84BZkq4FdgH+awnrlmQQwMCBAxrwbdrf4OVHtDoJDdfT337loSs1OCWt19NjsezKPi8qVhj+tganpPW6OhaFZYN6ss9mVZGNBh6PiLkAETFX0sy8vBhgxgDTCq+n522WtG5J3gmw4orL1Z/yDrT+Ad9pdRIabsSIoT1635m7nNjglLReT4/Fx88+s8Epab2eHouDvrpNg1PSeks4Fu8EHqp3n01rg2mxO4GPAk8Ac1ucFjOz/mIQKbjc2ZM3NyvAzABWlTQol14GAaPy8qLpwOos+DLFUsvi1i3Ja8CtPUy7mVknq7vkUtGURv6IeBqYCuyRF+0B3FPV/gJwFbC/pIGSRgI7AVfXsM7MzPqYZvYiOwA4RNL9wCH5NZKul/SBvM3lwMPAA8CfgJMi4pEa1pmZWR8zYP78+a1Og5mZtSGP5Dczs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBpgUkDcj/+/ibNUnlepO0TP6/7We/zbOmIGldSSs0+/N9g2uSqmCyFECeGdp6oBCk15b0wVanx/q+wvV2oKSVI6LtBwFWJhgmPR5lTLM/3wGmSSont6TTgG9J+kN+CJv1QOHm8GngSkkbgkuFRZKGSVpG0rKtTktfIWl5YEvgsjzlVNsqlF42A+6OiL81Ow2+GJugUDQ/iDRh51+Bd5Cea7NiK4qu7SIizgAmA5/Jr10qBCRtDVwP/BL4iqRNJC3d4mS1XET8G9gOeAz4eIuTU6o8sfCKwEXARpLe2+w0OMA0QUTMkzQY2B3YC9gIuDwi5gAfAT7fyvT1J93Um18BbCvpbEmd8giKRUgaIek9+eWJwDnAlcB7gS+SJot9T3fvb1fVpdpcbTQFOEfS9nmbtmyPyfeYb5Du9d+TtEWlZNMMHXsxtsBw4HbgIGDTiPhQXv5VUg7calCpGpN0GKkUeCfwIrAf8ANgA+AvLUtgax0MjJF0L/DPiLgGQNKvgM8BOwL3A/e1LonNlzN4o4CbSDOwv4MUYH4LHCXptoh4tpVpbCRJAyJivqS1gSERMQWYImkC6XH1f5d0WERUPy6l4VyCKVGhDnRQfmTBI8ChwNWSlpf0ReD1iLiilensb3KO9ClSo+UHga8D3yXdOH4laVzrUtdSvwCeJD1cbyNJX5C0YkQ8HRHfBQ6LiJtamsIWiYiZwKmkGdn/DhwBPA+sAfxMUts8A7nQPvkF4BZJJ0paISImAJsDbzQrLZ5NuQkknQ/8GPgH6SRfCXg3KSd5dkTc3cLk9WuSBuYc6mqkm+tRwPzcNtMxCrnW5YD1gb2BYaT2vluBv0TEm61MY7MVzo2lgQER8Xo32/0YmBgR/9fcFJZP0seAU4AVgHMi4qLCuoFlt1k6wJSk8PTOzUlF8ysjYo+87n3AHGB2RLzcynT2F4XjuQGwNekm+iPg78XqDUmfBb4NrNspDf6SVouIxyQJmBQRmxXa/DYHlgUuiYjftDShLSLpO8C6pAzIdcCdEfFYYf2fgfMj4uIWJbEhKpmM/PfSEfFGYd1xpOvi4ojYt1lpchVZCfIPXel/fgKp3WU5Sf+Rlz0IzHNwqV3heF4EBLAJcBlwuqT3Sxqa1w8ATumg4DIA2E7SNFK7woV51RsRcRmpgfcOoOldVFupUD19MOmZ8t8DdgO+AhwraStJy+VBl5P6e3CBhdonjwUulbRW5ThExKnAecDP8zZNufe7BFMiSfsBn4qIz0o6m/SY6MslXQv8JiImtTaF/UOhquNQUiP+wcDvgSNJpZjhwE4RcVfrUtlaks4Bvgz8E/hSpdpV0s7AzRHxTDGH2wlyu8rtwFbAMcCjwL2ktqqLI+LwliWuRLkkezqp9+BkUk/CHYGPRcSuzUyLSzANlnPTK+WXj5HaBCD1dtokV/Gs5OBSG0lLFUojg4EJwPHA/+Y685OAGzs1uBRyopcB7yNVx94h6ceStiKN4H4NFmr87RQrkto8BwAfjYjzIuJm4FfAtZDOr5alrgS5Kjki4tOkRv7tgIuBPUg9yJo6GNkBpvG2IlWHfZh043s0L/8dqXfPDaQeT1abYyRtm/8+l1SP/jLwZG683Z+UQ+u4UfyFkt1KwIsR8WBEHAusRrq5HgIcGBEvNHPsQytJ2k7SNZL+MyIej4grSb2m7pf06dwWMSwHGtqh40OhOvD9wLmSbsg1JoMj4uOkHnPbRsQfcim2adXHriJroHyDq1zIV5Mu8nMjolLveSqwZkTs1qIk9iuS1gKOJh3TaaSOEg9I+hQpZ/5nYEREbN7CZLZEodfYasDPgOWAkaSuyFflbYZHxHMtTGbT5V5TWwHvAaYCl0XEo3kMyMbA0sBxEXFHM3pRNZOkv5DGgg0knQ8bA6e2YoqYCgeYEuRBgH8mjdH4DDCb1IPj78CKeUyM1SB3uz2ZNH/Ug8CNpHrl1YEhwMyIeK7Sy6x1KW0NSWcBb0bE15SmIjqddJ4dEBF/bW3qWkPSNqSBpZuS2lx+GREXKM1D9mpEvN5u7VGSdgC+EhFb59cjgDOAF4AjWxVIO6pKoUyFYupuwKdIAWYiKbDcCVxDavB3cKlBoW78Y8BY4EzSOKIPkRr21wMerOTQOym4aMFM0uuTZjGYCBAREyNiGGlA70mtS2HLnUSqNv0KqdfUHpJ+Bny8MhamnYJLNh14U9I6uYvybFIpf/VWltIcYBqkcIM7htQteTjwTeA3wJrAeNLUFFaDQt34McB3I+ISUpfv60ilmR1ZUB3ZUQo3xy+TOjwcV7X+c+TJPzul7aVC0nbACxHxq4i4nhRgbgFGkRr729VDpLF1xwAfyR08TmVBZ4aW3OsdYBooj3N5gTSo6wTSCb0RsDIwLSJebWHy+hVJA/LN8V/ABpIGR8TciPgZcDPw84h4pdMa9osi4mBSsN1K0sOStiysm1v8v4PcDwyQtK2koRHxImlW6Uci4trWJq1xKiV8SUPyNTCXlOGYRRr7tBdwe0RcCq2bZbxjL84yRMQ9pBLLd4Cn8tw/Q4DRETG9lWnrbyJifr45/hHYHthB0saS9gHWjojr8nZt00i7JCrM+Cvp7ZJGR8RNEfEu4PvADZKuaV0KW6NQZbgqKSf/B2BXYK/cLvV9UtfktulpWCjhf5/UM/U8YGdSrcmOEbE3aUbtln7ntjjYfcw5wPsj4vScA/8hqRrDeiAifgJcChxOmtTy06SLqOOqf8hVPJK+QWp3uVfSBZI+GRFnA28jd4FvlxtpLXJvurHAlJwpOYU0B9uGpNqEn+WSb1tkSCRtnP//OLA2cBqp5PYx4Czgs3mGAqC139m9yEqSi7AfIo2ePaXV6emPVDW3ErAqMD0WPB20rbqZLk6hW/K7SA8R2wxYnjSp5eeBgyLihhYmselyBmNwripdgTTYdJ/Ic9NJWi4iXips3+/PF0nvJGVipwGrkILqb/P95iOkKtO3A4dExCutS2niAFOiXHQf1A6DuVqpU7sgd0XSUcDYiPhyYdmRwFLReTNIHwO8TmrInk2ab+zEiJiWx1DtBdwQEX9qXSobS+nx1zsA/0GaNmkZ4IiImJrXDwdG5vFiLQ+obTVNQl+Tc98OLjVY3LiESnApjFx/O7BRRPy6qYnsG24GPiVpRO6KCukm867WJallngd2IY03m0yaEuc6SVNJVWO3kcYEtY1cKrlS0m2kUuwngS/n73xdpFmin8vbtry01jH1tNZ3VVWFbdXddoUL5hyg9Kfx9VF/A2YCMySdlhuxdyfN0dZpbS+TSA3bD5LGvmxGmtzyh8BHIuLgiHixnY5JpUNDRDwW6UGF55AeorYRcJKkd7QyfdXa5sBbv/ZhSespTTP+n7DojbLQLfMTwMBOGaVeGMD7LkkbkR7zMJ70TJx1gKHA1yLi8b5QJdIMhV5jgyLiuYg4gTQV/w2kp5xuRpqPDegbOflGKWTEKoHmr8DZpKmpbomIJ4vrW81VZNZSSlOqDydNB7MOadbXt24KkoZFxAuFdqyvk+rW214u2c2VNIz0RNRVgCckXQH8NCJ2LG7fTjfSGn1Z0ihSo/YPI+KwXAI+ljQgt20VA02uQr6h2Kuyr8xU4BKMtVSkh67dQqpPfwI4QNJxuVcQwBmSxsBbjdm3VXJp7a5wkziC9L3XAq4gjfGYKGmXYnfUTpBLafOVJrXcnfT8m62AeXndjRHx8UqjdztYXGmkEGiWypmRt+fZDPoEBxhrmUIx/wXSsyu2IfUIEumJfNeTplafnredS5r+ou1Vqghz1eDvSY37lXaHXYBnSF3gO2p2iEIp7VBS4H2VVDU0FXiPpGPURs94qaN9slLC71Ptk23zQ1j/U7hw3kMaJPhsREyRdAfp2TkidT2tbH9uSxLaAoUb6Vmkdqk3JAHcERGzgMMrpZdOaXuBtzIlQ0idHUaS5mHbOa/+KvB0mw0L+LCk50kPDhsG3Fj9e+fSy5t9sX3SAcZaojK2RdK+wGdJpZOlJN0MXJgnt6xs21ZTqy9JoTv2dsD7ga8BO5GqhNaTdDepRFN5UmVHBBd4K1PyqqRngUtIjz5+VNLmwDhSb6q2OGfaoX3SVWTWdIXG6yGkKdX3JA2Ym03KrV8h6QuV7fv7jaJehYCxLfCtiPgtcBhpPq33kdpg+v0NtB5aeB62IRFxHmlanH0l/YZ0fE6O9KyXQe1wbNqhfdIj+a1llB5fuwJpkNxPI+IDkg4hVQdMiIjbW5rAFsqN2JUHRn010kSqSFoFWC0i7m6HXHotCiW61UiBZFnSQ9YOl7QGqRfZP3NbXluoantZgVSFvBmpe/oKwGBSlfJeOfgeCpwfEa+1KMldchWZtdLFpJkO9iI3YpNmw53ZycEle4j0+NvNgC9VjdR+GjqnZFco0Z1LytFvSBr/A+mBa09ExGvtFHDbpX3SJRhriaoc2qbAf5F6S+0EfCkibu2kxuvuSNqANIGhSFXax/W1apBmUJpB+PiI2E7SrcBREfHnPB/ZnyLilhYnsWG6a58kZcIujIhnCtv26aDqNhhriaqL4u+kgYRvAJNzcBnQycGlv4zUbqJlgNsknQVEDi6jgf2AB1qbtMZpt/ZJBxhrmu5uihHxHDAxIk6MiHPy4oEdeBN9S/VI7UhT8V9evb6dVY1M/wPwHlKO/lylWYNPAa6IiCfUJs8GKvyuRwE3ASOA1SNiL9JUOAOAaFHy6uY2GGua7m6KWvCsk6Uj4o1K98tmp69VFlfNUTVS+0110EzSOSf/NtID575M6vQwmvSArSHAwxFxUt683Uq7bdE+6RKMlU7SeyRtlW8WlWVvlU4qN9GIeCMv+oX62KywZenvI7XLlEslr5GqiI4FpkXE5qRHkn+O1KPsreljWpbQBsvnxBN5QO2dwEcknQqcCVyYt+kX9+5+kUjr9/YBvkQas7A+LDorrBbMGrwr8PcOasj2TNJVCtVdg/NEjkeSelIdARARt0TE05Gf2NhubXXt1D7pXmTWFJIOB7YAlia1JdwaEY/kdW/1FpN0O7BlJ1SR5RLdx0n17esAe0TE7wvrF6oqlHQTsFenBF9J3yO1QZxJGmB6Gqm66JiIaKtS3OKqSavX5QA8rz+U2lyCsVIVcuPrAPeRqjx2AI6QtKWkkYXgciJp6o+2Dy7QHiO1yyJpJWBN0qwF3wTmA38iPfdlyxYmrRS1tE/m18Nyp48+H1zAAcZKlkdg7wisHxFHRcT2pG63m+X/xwFIWhH4ALmOud3JM0kvoqpd7tmI2IbUuP83UuZkP+Bo4Krq7furHrZPvrPJyewx9yKzZliG9FjbyjxSt0s6mFSnfgtARMyRtE+uc2977TJSu5EKx+Qg0vQvfwFeAWYB746IP5MyJX1+gGEd9gHWAsZKujki/lbVRX1+YeBlpX3yiZamuA5ug7HS5Wqea0g5z7NIXUx/RBo4OKlyAbUyjc3UTiO1y5A7M3yOFFg2BD4CLAecHRFHtzBppWjn9kkHGGu4LhollyblyK8k9e2/H1gpIj7RoiS2TCFXOgT4P+CTwAWknPqKwCDSxJ+XtC6VfYPSxJ6vkZ5YuQ2pF9Vt7RJ0tWASzx+RJjUdS3qA2hPAr4F7clflSvvkExHxo5YluAdcRWalkXQ0aebX95OmnV9X0seB6cBzeZuOKr0sZqR2cSbpfjNSuwyVG29EPJ0X/UzS1YWuuQNIjf79WlX75CYAkjYBJgGbk86RGwvtkzu1Kq095UZ+aygteGb6R0gXxP8Ba7Ng6pd7I+Ih4FlIo7VbltjWupjU/XZ7+vFI7TJUj/FQ1aSn/WUMSI0WaZ8EDibNr/ZW+yTQL9snHWCsoQoX/0GkAXKDgL/kC+ddwGGSlm2HKo6eaqeR2r1VT08wSe9QespnO7kdeK+krwFzJS1H6jl3Q0S8Uhl0WmyX60864iS25pE0ILe5/A1YFziJNM0H+f9hlRHYnaqdRmr3Rh3T5FSOxdn082lyugioT5C6qY8n9Zq7BHhHREyC/l/Cd4CxhiiM65if++w/QCrB3Ao8n9teNgGOK27fKbr7vtHZM0l37DQ5ko6WdDLwC2C5iFgXOJyUCds1b9PvZ4h2gLFGGQYg6RuSPkPqlvxj4MPAFFKV2UmVYn+nVZG160jtnsoDC4cD55FurDfBgtKKpGH5dWWSz6/n7fqtTmyfdDdl6zWlZ6UfAbwE7AJsFhFPFdYNBx6IPva88GbIAylXB/6Yp4ZZ0rxTvwP27E+D6XoqB5HLgDVIXdf/SirNPS/ph8BpeSaDI4EVIuLE1qW2cST9BPgusAppbrndJb2bVFV2WjtVIbsEY70W6TnxvyL1fhkCrCVp+cK6lSI/M72FyWyVnswk3dbBpVOnyenE9kmXYKxhJB0GDCXdVO8EjicFnZUjPZGvI7XzSO3eqJom51FJa1KYJiciZrbDoMouBh7vDJwI/D7/vyGpqvCDuQq533/nCgcYazilpy6eDqwHPAUcFBHTqscztLtOGKldr06cJkfS8hHxb0nfAP5FKq0dA+wMPAO8CFwZEVe128BjBxjrscLN4jOkHmJbk0bsX53Xrwa8HhFPd1pwqcgjtY/tYqT2QOCoiKiM1L4M2Kmdbi7VOnGanE5vn3QbjPVIvlnMlbQscDLpuekDgcsk/UnSRyPiscp0H50YXLK2Hqldj8VMk7MXcANpCpi2mian09snHWCsRwo3iwnAT0iTWD4ZEZXnWvxB0vtbkbY+pq1HavdQR02TExE3A98izdJwKTBJ0lqSvkvqANJtN/b+zgHGekzSMsA0YCJpnMI1edVFpOqfv7Qqba3SaSO169Wp0+RExLkRcQrp0QOvksaGrQV8A9rzO4NnU7YeyjeKVyVNjog3JE0DlsoD6I5gwWjkTm178UzSXehmmpyRtNk0OUton9ynU9on3chvdSlcOO8kjd5/L3AjqcH256R2hYcj4svt0guoVoVeYx8BvgOcQup+Op70PPmVImJ2Bx6XxQ0sre7COwiY15+PT6Ezw7LAXcBupGchvQu4F/hqRPyxlWlslrYslll5CjnuycCBwGnAzhHxa9IYmC+SpoWB1GjbMcIzSXep06bJcfvkAg4wVrNKPbGko0iNsj8gXTy/lLQCsBHpQnoTOq/nWCeO1F4cSe+RtFWuNq0seyvTUbkRR5ocFeAXuWTc77l9MnGAsZrl6p+lSYHku8BXgCsi4t/AZsChhZtFx5Bnku5OR06TU2mfJLUrPUcKNMX2yZvydm1//237L2iNlW+gV5O6XW4QEWfkVYfn5R1x4VTxTNJdiIivAX8kNXCfJWlvSe/K6+bnNqtKlesR5B5V/ZUWTK//DkljgW1ySeYO4AzS1Py3RMTf2qUzw5K4kd+WqNB4/R/AnsD/kAZXPgj8ARgHjIqI7VuYzJbo9JHa3enkaXIk/ZpUit0KODUirsgl/3eQvueb7dxzrKjTcprWA4ULYV/groi4kTS24yVSW8PdpMGDbfGQpHp0+kjt7uTgsiOwfkQclTMfZ5OqUs8mZUrI0+R8gDwGpr9y+2TXHGBssQp15ZsDKwOvAUTEPyNif+DoiJgUETPz8o4a1wGdPVJ7CTpmmhy3T3bNAca6VTVGYRNgc+BQSesWpjh5vWUJ7EM6daT2EnTUNDlun1yU22CsW4V69MNJOdF7SF1vNyM91+SiiJjeuhS2zhJGanfkTNJdDJpcmvRslytJ1UX3k6oMP9GiJDac2ycXr6OiqdWu0stF0jtIuc6/R8TjEbEvaWT6Z0h16R1Hnkl6sSQdLelkUq+p5SJiXVIu/lgWTCHUFm11bp9cPAcY61IhJ/pl4FeRnjg4LK+7DTiU9NCkjiv2e6T2onJOfn6eJmcn0vNe1gYG5na8eyPiIeBZaI+2OrdPLllH3RisR6YCo+GtZ6gj6Vhg/4h4OC/vqBw6eKR2tU6bJsftk7VxgLEluQtYVdJFknaQNI5U1zwBOq/0Ah6p3ZUOnCanUno5HPgr8B/Aw8AvgeMljWld0vqOjrkArGci4nFgP9LFcxapm+l5EfFApzReV3ik9qI6cZoct0/Wzs+DsSWKiPslnRIR35a0VGWwGNAW1R21ioVnkq6M1B6WR2oPJY/UztsMoDOOzzDg35K+AfyLVFW4FrAzqav2iyw8TU6/b4forn0yIl6IiNskHUp67k/HPg+pwt2UzWpQ6I56FDAG+D7p+TebkoLJusCdnTSYrtOnyckzFeweEXsUlh1Lmr1gz9alrO9wFZlZDTxSe1GeJsftk0viEoxZHSTtDOwArBYRm+dlvwcmRsTVnVglIukw0sPm9gHuBI4nBZ2VI2KvVqatbLktblfg86SZo2+PiMmdeB50xQHGbDE8Urt2kt4OnA6sBzwFHBQR09r9ZqsFT+Z8q32yelaDTuUAY1YDSd8Hbo2In0pah9T28ArwD1JD78x2acReEk+TY7VygDHrRiFnujlpVuQrI+K/C+sHd9pgusIxWZbUBrEbaa6xdwH3Al+NiD+2Mo3Wd3R8I5RZVzxSu2ueJsfq4QBj1jWP1O6Gp8mxWjnAmFXxSO3ueZocq4dPArMqnkl6UZ4mx3rCU8WYdW8qsDssMpP0WyO1O+VG6mlyrCfci8ysG5JWJc2n9SBwLfAY6eFin+mkyT49TY71VEcU7816wjNJJ54mx3rKAcZsMSLifuCUiFgb+FJETM6rOqronwPI1cC3gA0i4oy86vC8vGPao6x2riIzsy55mhzrLec4zKxLhSrAfYG7IuJG4Auk6fnXBe4m9bQr9jIze4tLMGa2CE+TY43gbspmtpBupsl5u6T7gfsiYq6Di9XCVWRmVs3T5FhDOMCY2Vs8TY41kgOMmb3F0+RYI/kEMbOuTAVGwyLT5OwfEQ/n5R0x0NR6zo38ZtaVu4CjJF3Egmly9iRVkdFJMxlYz7mbspl1Kc+avCvweeCPwO0RMdnBxWrlAGNm3SqMh1kqIt4sLmt12qzvc4AxM7NSuJHfzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUHmhptgSSHgXeDswtLB4bETN7sb/9IuKm3qfOrO9ygDGrzfZ9JSAUx6SY9WUOMGY9IGkF0qzC2wDzgIuBEyNirqQ1gcnABsB84EbgoIh4TtLlwBjgV5LmAicBdwBXRMRqhf0/Si7lSJoArAe8CuwAHCnpqsV8/lrAhcCGwBvA/0bEbmUeD7OuuA3GrGcuAd4E1iI9L2VLYL+8bgBwGjAKeC9p0sgJABGxNzCdVCIaGhFn1Ph5OwJXA8OBHy/h808GfgusCKwGfK8nX9Cst1yCMavNtZIq1VK3k57yODwiXgFeknQO6dHCkyLiQeDBvO0sSWcDJ/by82+PiGsBJC1PKrl0+fmkUsvqwKiIeAy4tZefbdYjDjBmtdmp0gYj6YPAVsATkirrBwIz8vq3A+cCHwWG5XVzevn5Mwp/rw4s3d3nk57XcjJwh6Q5wFkRcVEvP9+sbg4wZvWbAbwGrNxNY/uppLaX9SPiWUk7Ad8vrK+eAPAl4G2VF5IGASOrtim+Z7GfHxFPAvvnfW0K3CTpllyyMmsat8GY1SkiniC1cZwlaXlJAyWtKeljeZNhwIvA85JWBb5atYungHcXXt8PLCNpW0lLA98EhvT08yXtIqnSYWAOKTh5en1rOgcYs54ZDwwG/km6iV8NvDOv+xYwDngeuA64puq9pwHflPScpKMj4nngK8AFwOOkEs1jvfj8jYA/S3oR+CVwWOUplGbN5On6zcysFC7BmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkp/h+zAPVpm1RIewAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZgAAAF6CAYAAAAkt07cAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAA8eklEQVR4nO3debgcZZn+8W92kAQCIagsARVyK4swUUQUfiLKIvsoWwSiCCjKvoiIAhGGRYZF0DjEsG8RiAyKIDiMAsKggBARlYedBMISwhZ2SPL74307qXTOyek+OdV9Tvf9ua5cOV1V3fV2dVU971795s2bh5mZWU/r3+wEmJlZa3KAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQNMLyLpGEnnNTsd1jMk/YekFyQ92+y0lEXSZpKe6qHPkqSpkmZLOrgnPrMnSTpX0rHNTkd3SHpN0oe78b4luif1a5VxMJKeAN4PzCksHh0RM5bwM/eNiJuXLHV9j6TxwJoRsWez09IXSRoFBLB6RDzfQ585D5gJrBwR7+Vlg4CngZER0a+Gz1gDeBwYVPmMJUzTZsBlEbHqYtK8VkQ8UsNnnQ+8GhGHLWm6lpSkr5Ou/U0asK/hwJnANsAywDPABRFxal5f8zHM299C+k3qCgxd/Zbd0WolmO0jYmjhX7eDS0+QNLCZ+++uvpruJSWpn6SeuiZGAbO6E1y6OP4vAV8qvP5SXtYKVgf+0Z039vFz9ixgKPAxYDlgB6CmYNLbtVoJZpHShqTlWJA7mAtcCBwfEXMkfQSYBKwPzANuAg6IiJclXQrsAbxNKhWdANxFVYQv7jfn+tcF3iKdJIcDV3e2/w6+w3hyqaGQ0/xG3vdQ4PvAX4HzSTewyyLiwPzerwP7AfcBe5FyQQdExP/m9SsD5wKbAC8CP46ISYX9FtN9TE5zv/z9H42I9SXtDRwFrErKSf84Iibmz9gMuIx0sXwvH7NjIuLCvH5p4D+AnYHhwN+BLSLiTUmfzvtbG3gSOCQibqk+PvlzvgccDCwLzAC+ExH/K2lA3u8+wErAQ8BOETFd0meAs4HRefkhEfF/+fNuAe4ANgPGAOsBA4GfAp/I3/PYiLgqb78NcDqwGvAqcFZEnF6Vxi8C1wFDgDeAKRHxdUk7AKcAqwBTgW9HxL/ye54A/ot0zglYprqEkXOyxwLrR8QuedkU0m/+H5USTPW1UHVeTctpfz1/7BbAVhRKq9WlnFp+91pKMDkda5POs38HpgFfi4h7JP0B+BzwLvBe/i2ey7/Dl/JxnAScHBFzC+f7XcC4fOxWzdt9CNgU+BvwFeBo4Gv588ZGxH05bUfnz1gJmA78ICL+W9LH8jEdBLwJvBcRwyVdBDwVET/M79+PdM6tANwO7F/J1Obv/W3gCGAkcDlwYEQscsOV9ADww4i4toN1t+Xv8gbpHrUP8HvgUmAj0rl6R973U5JOyt+3chwviogDq36HRc7hfPxeYME5C+l6+SYLnxubAKfl33E26dq4qDrdFa1WgunIRaQDvSbwb8CWwL55XT/SBb8yKfewGjAeICL2Il0AlVLRaTXub0dgCukmenkX+6/FRsBawG7AT4AfAF8E1gF2lfS5qm0fBVYEjgeukbRCXvdL4Kn8XXcGTpa0eSfpPh84Gbgyf/f18zbPA9uRbu57A2dJGlP4jA+QcmCrkC6ECZKWz+tOJ92wP0O6II8C5kpaBbieFHxWAI4EfiVpZPWBkCTgQGDDiBhGujE+kVcfDowlBfJlSYH5jfz9rwfOAUaQAtn1kkYUPnov0oU0jHQD/R/gCtKNZ3fg55LWztueD3wr739d4A/V6cw39i8BM/Lx+7qk0cBk4FDSDecG4DpJgwtvHQtsCwxfTPXVtcD/kzQ8H9tNgV93sm1H/l/+f3hO2501vKer370eO5DOxeHAb4CfAUTE5sCfSDfhoRHxECm4LAd8mBR8xuX9V2wEPEaqGj8pL9sV+CHpGngbuBO4N7+eQvr9Kx4lHb/lgB8Bl0n6YA76+wN35rQMr/4S+do5Je/vg6SM0S+rNtsO2BD4eN5uq06OyZ+BkyTtLWmt4oqIqPxe6+e0XEm6b19IKvGNIgXBynH8AQsfxwM72N8i53BEvM7C5+wiNUCSVgd+R/pdRgIbkDJKnerLxcqOXCupcmHeAnyLdMMZHhFvAq9LOot0M5mY6zQrRdGZks4k3ZiXxJ2VnIikZRe3/xo/78SIeAv4vaTXgcmVahdJfyIFrVvzts8DP8m5pCslHQFsm3PpnwW2zZ81NTfcjWPBDXJ+uoE30718YRFxfeHlrZJ+T7pA783L3gVOyDfHGyS9lpKpu0g3/E9HxNN520oJYk/ghoi4IS//H0n35ON2cVUS5pByWGtLmhkRTxTW7QscFRGRX/8tf/5ewMMRcWlePjk3IG9PCv6Qcnn/yNtvDTxRKXkB90n6FbAL6Sb0bt7/3yLiJWqvntoNuD4i/ifv53TgEFLAvSVvc05ETO/ic94ilY52I2WQfpOXlaaG370et1d+61xLcGhHG+US6e7ABhExG5gt6QxSZuD8vNmMiPhp/vu9fM7+d0T8NX/Gf5NKuJfk11eSMiiV73V1YZdXSvo+8ClqC9h7kNpJ7s2f/X3gJUlrFM7LUyPiZeBlSX8k3ZBv7OCzDgIOy2n7haQngYMi4ncd7TgiZgG/qrzOpZY/1pDmiu6ew18Fbo6Iyfn1rPyvU60WYHYqVpFJ+hSpmPtM4YbZn1QcRtL7SVUnm5Jyr/1Z8vrs4g1i9cXtv0bPFf5+s4PXQwuvn64qgj9JKrGsDLyYL9Tiuk92ku4OSfoSKQCPJn2P95GquipmVeW838jpWxFYipRjrLY6sIuk7QvLBtHBBZOL94eSSpnrSLoJODzntFbr5PNXJn3XoidJpayK6t9sI0kvF5YNJFVJQKpy+SFwqqT7gaNrLAUslI5czTN9MelYnEtIued+pCqaUtXwu9ej2KPuDWApSQM7KLGtSDoPir/d4n63ipqvF0njSCXfNfKiyrlai5UpBNiIeE3SrJy+J/Li6u9avFbny5nPk0m1CsuSqriuljQqIl6s3l7S+0jVWlsDlRqCYZIGdFT13oHunsOdXWOdarUAU206qZi8YidVDieT6jXXi4gXJe1ELmpm1fWlr5MuLmB+Lqu6Kqf4nq7239NWkdSvEGRGkXK4M4AVJA0rBJlRpN5HFdXfdaHXkoaQck3jgF9HxLuSriXd5LryAimX/RFyyaJgOnBpROxXw+cQEVcAV+QLcSLwY1Kudnr+/Aeq3jKDFDSKRrFwTrL6N7s1IrboZP93Azsq9d46ELiKdOF1ZQapfQdIHQry+xb3G3TmT6RqmXmkuv+PVK1f6DwlVV0ubh+dbr+Ev/uSeIGU014d+Gde1tU5W7Nc3TMJ+AKp9D5H0lQWfK+uPnuh80rSMqQq2Kc7fUcNIuJVSSeT2ls/RGovrXYEqZ1uo4h4VtIGpDajmtK+mHO4q+88nVTCq1lLB5iIeCYX589Q6r/+GulHWzUibiWVWl4BXsltAd+t+ojnSPW/FQ+RclzbkhrajiFV2XR3/z1tJeBgST8HdiK1K90QEbMk/R9wiqQjSTnRfUjF/M48B2whqX9EzAUGk77rTFJ1xJdI7UnVN/RF5Nz6BcCZucrqOdKJei+pY8DdkrYCbiblWj8NPBIRC42vyG0wq5AaNd8i5UgH5NXnASdK+iep2nM90sV+A/BTSV8lXUhfITVQ/raT5P6WlLPbiwV16huQfrtHSVVlv42IVyS9Suq4UYurgKMlfQG4jVQ99ja5qrAeETGvUuLLf1dvMhXYXdLvSB1YdmZBQJ2Z0/xh0vlc2f57Sl2rXyHd3Cq6/bsviXzDv4rUNjGO1D53OKktrycsQ7qhzgRQ6siwbmH9c8CqkgZHxDsdvH8yqbr1CuBfpMzqX6qqbWuS7w03kjJf/Unnxsukbu6VtHyYBdX5w0jn/stKbYzV1frV963ivgbT+Tn8HDBC0nIR8UoHb78cOEbSrsA1pLar1SJiamffrR0a+ceRLpJ/kqq/ppByf5Dq1MeQLqrrSQet6BTgh5JelnRkPujfId3Mnibl/LoaZLa4/fe0v5A6BLxAavTcOdfXQmpAXoOU8/pvUk+2xY3vqdRPz5J0by75HEy6Ub5Eqo/9TR1pO5JUrXI3uRcb0D+3OexICtYzSbmk79LxuTkEODV/v2dJAbVyMzwzp+33pJ4x5wNL5++/HSnXN4vUuWC7iHiho0Tm77klqf5/Rt7Pj1mQkdgLeCJfmPuz+CBd/NwA9iQ1kL5AagPavpObVy2f949Ku1EHjiWVal4ineNXFN73BuncuCOf15/O7UJXAveTein+trD9kv7uS+Ig0jX2GKmkdgVwQU98cET8EziD1AngOVKG5I7CJn8gdZl+VtIi50q+do4lle6eIR3v3buZnHmkRvsXSOfcFqT20tfy+vHAxfn32pXU2WfpvP2fWbRd52xgZ0kvSTqng/11eA5HxIOkwPlY3tfKVd95Gqlt9AjSNTyVlIHpVMt0U253auDAMDOzWrRDCcbMzJrAAcbMzErhKjIzMyuFSzBmZlaKlu6mXDCENGXDMyw827KZmXVuAKnX692kbvV1aZcAsyFpcJqZmdVvU1JX8bq0S4B5BuCll15n7ly3OZmZ1aJ//34sv/wykO+h9WqXADMHYO7ceQ4wZmb161bTghv5zcysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NStMs4GLO6LbvcEIYMHtzsZPSot995h1dfqXvGD7NucYAx68SQwYP5+oWHNDsZPeqivc+mG1NKmXWLq8jMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlaJhk11KGg1cDIwAZgHjIuLhqm22BE4G1gN+GhFHFtYdC+wOzAHeBY6JiJsalHwzM6tTI0sw5wITImI0MAGY2ME2jwH7Av/Zwbq7gA0j4uPAN4ArJS1dVmLNzGzJNCTASFoJGANMzosmA2MkjSxuFxGPRMRU4L3qz4iImyLijfzyfqAfqTRkZma9UKNKMKsBT0fEHID8/4y8vDvGAY9GxFM9lD4zM+thfe6BY5I+B5wIbFHve0eMGNrzCTLrY0aOHNbsJFibaFSAmQ6sImlARMyRNABYOS+vmaSNgcuAHSMi6k3ErFmvMXfuvHrfZm2qVW/EM2fObnYSrI/o37/fEmXMG1JFFhHPA1OBsXnRWOC+iJhZ62dI2hC4Etg5Iu7t8USamVmPamQV2f7AxZKOA14itaMg6QbguIi4R9ImwC+BZYF+knYH9sndkX8OLA1MlFT5zL0i4u8N/A5mZlajhgWYiHgQ2KiD5dsU/r4dWLWT929YXurMzKyneSS/mZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBxszMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWioGN2pGk0cDFwAhgFjAuIh6u2mZL4GRgPeCnEXFkYd0A4Bxga2AecGpEnNeg5JuZWZ0aWYI5F5gQEaOBCcDEDrZ5DNgX+M8O1u0BrAmsBWwMjJe0RjlJNTOzJdWQACNpJWAMMDkvmgyMkTSyuF1EPBIRU4H3OviY3YBJETE3ImYC1wK7lJZoMzNbIo2qIlsNeDoi5gBExBxJM/LymTV+xijgycLrafn9NRsxYmg9m5u1pJEjhzU7CdYmGtYG0xvMmvUac+fOa3YyrI9o1RvxzJmzm50E6yP69++3RBnzRrXBTAdWyQ31lQb7lfPyWk0DVi+8HlXn+83MrIEaEmAi4nlgKjA2LxoL3JfbUmp1NbCfpP657WYnYEpPptPMzHpOI6vI9gculnQc8BIwDkDSDcBxEXGPpE2AXwLLAv0k7Q7sExE3AZcCGwGVrs0nRMTjDUy/mZnVoWEBJiIeJAWI6uXbFP6+HVi1k/fPAb5dWgLNzKxHeSS/mZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBxszMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFAMbtSNJo4GLgRHALGBcRDxctc0A4Bxga2AecGpEnJfXrQRcCKwGDAL+CBwcEe816juYmVntGlmCOReYEBGjgQnAxA622QNYE1gL2BgYL2mNvO4Y4F8R8XHg48AngC+XnWgzM+uehgSYXPoYA0zOiyYDYySNrNp0N2BSRMyNiJnAtcAued08YJik/sAQYDDwdNlpNzOz7mlUCWY14OmImAOQ/5+RlxeNAp4svJ5W2OZEYDTwDPAscFNE3FFmos3MrPu63QYjaWlgbkS83YPpWZxdgPuBLwDDgN9J2jkiptT6ASNGDC0rbWZ9xsiRw5qdBGsTNQcYSacDV0XEXZK2BaYA8yTtFhHXdfH26cAqkgZExJzcmL9yXl40DVgduDu/LpZoDgK+ERFzgVck/Rr4fE5HTWbNeo25c+fVurm1uVa9Ec+cObvZSbA+on//fkuUMa+nimwP4IH893HAnsAOwMldvTEingemAmPzorHAfbmdpehqYD9J/XP7zE4sCCCPk3qXIWkw8MVCeszMrJepJ8C8LyLekDQC+HBE/CoibiaVOGqxP3CQpIdIpZH9ASTdIOmTeZtLgceAh4E/AydExON53aHAppL+TgpWDwGT6ki/mZk1UD1tMA9JqnQj/h8ASSsCb9by5oh4ENiog+XbFP6eA3y7k/c/CmxRR3rNzKyJ6gkw3wHOBt4FvpGXbQX8vqcTZWZmfV/NASYi7gY+U7XscuDynk6UmZn1fXV1U5a0BbA7sFJEbJ/bTpaNiD+Ukjozs15muWWXZvCQhs2y1RDvvP0er7xaU2tHXerppnwQcAhwHrBzXvwmae6wz3T2PjOzVjJ4yEBO/kHNoyP6hGNO2rnrjbqhnl5khwJfjIhTgbl52YOAejpRZmbW99UTYIaxYGBkZbTiIOCdHk2RmZm1hHoCzG3A0VXLDiZNm29mZraQelqqDgKuk7QfaVbjAGYD25WSMjMz69NqCjB5ivyPAZsC65FG708H7spzg5mZmS2kpgATEXMl/ToihgF35X9mZmadqqsNRtKnS0uJmZm1lHraYJ4kPYPl16Tqsfnz3kfEcT2dMDMz69vqCTBLkx5hDLBqYbkfsGJmZouoZy6yvctMiJmZtZZ65yJbi/SwsFWAp4HJEfFwGQkzM7O+reZGfknbA38FPgq8SJoi5h5JO5SUNjMz68PqKcGcDOwYEfNH7kvaDPgZ8JseTpeZmfVx9QSYVYE/VS27nYUb/M2sBQ0fNphBSw1pdjJ61Ltvvc3Lsz2VYpnqCTBTgSOAHxeWHZ6Xm1kLG7TUEG4Y11r9fLa55EJwgClVPQHm26S5yA4hjYNZDXgD2L6MhJmZWd9WTzflByV9DPg0sDIwA/hLRLxbVuLMzKzvqueJlhsAsyLi9sKy1SStEBF/KyNxZmbWd9UzF9llpAeMFQ0GLu255JiZWauopw1mVEQ8VlwQEY9KWqOWN0saDVwMjABmAeOqB2lKGgCcA2xNmoLm1Ig4r7B+V+BYoF9e/8WIeK6O72BmZg1STwnmKUljigvy6xk1vv9cYEJEjAYmABM72GYPYE1gLWBjYHwlgEn6JDAe2CIi1gU2AV6pI/1mZtZA9ZRgzgJ+Lek04FFSIDgCOKmrN0paCRgDbJEXTQZ+JmlkRMwsbLobMCk/xGympGuBXYD/BA4DTo+IZwEiwsHFzKwXq6cX2SRJLwP7kAZXTgcOj4hf1fD21YCnI2JO/qw5kmbk5cUAM4r0WICKaXkbgLWBxyXdBgwFrgFOigjP5mxm1gt1GWAkfQJ4OyIeiIirJd0K/ARYF9hS0k0R8VrJ6QQYAHycVAoaDNxICkCX1PoBI0YMLSdlZn3IyJHDmp2EXsPHYoEyjkUtJZifAD8CHsivf0EaBzORNLPyacB3uviM6cAqkgbk0suA/BnTq7abBqwO3J1fF0s004ApEfE28HZ+8NmnqCPAzJr1GnPnusBjtWnVm8/MmbPrfo+PxQLtdCz69++3RBnzWhr5P0aeg0zScGBbYM+ImEAKMF2O5I+I50lTyozNi8YC91W1vwBcDewnqb+kkcBOwJS87gpSiamfpEHAFwCPvzEz66VqCTADgcqEPZ8GnomIhwAiYjowvMZ97Q8cJOkh4KD8Gkk35B5ikMbUPAY8DPwZOCEiHs/rfgk8D/yTFKz+AZxf477NzKzBaqki+wepJ9dVwO7AzZUVklahxq7CEfEgsFEHy7cp/D2HNOdZR++fS5pc8/Ba9mdmZs1VS4D5HmmSy3OBOaTxJxW7AXeUkTAzM+vbuqwiy3OPjSL13vpwRERh9fWk8SlmZmYLqWkcTETMJj0uuXp5dLC59WHLLzeYgYNb68FS773zNi+94ud+mDVaPSP5rQ0MHDyEv562b7OT0aM+cdR5LOinYmaNUs9cZGZmZjVzgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBxszMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpBjZqR5JGAxcDI4BZwLiIeLhqmwHAOcDWwDzg1Ig4r2obAfcBP4+IIxuRdjMzq18jSzDnAhMiYjQwAZjYwTZ7AGsCawEbA+MlrVFZmQPQRODashNrZmZLpiEBRtJKwBhgcl40GRgjaWTVprsBkyJibkTMJAWSXQrrjwZ+CzxUborNzGxJNaqKbDXg6YiYAxARcyTNyMtnFrYbBTxZeD0tb4Ok9YGtgM8Dx3YnESNGDO3O26wFjBw5rNlJ6DV8LBbwsVigjGPRsDaYJSFpEPALYO8cnLr1ObNmvcbcufN6NG2tplUvuJkzZ9f9Hh+LBXwsFminY9G/f78lypg3qg1mOrBKbkOptKWsnJcXTQNWL7welbf5IPAR4AZJTwCHAvtJ+kW5yTYzs+5qSAkmIp6XNBUYC1yW/78vt7MUXU0KHNeQepvtBGwaEdOAFSsbSRoPDHUvMjOz3quRvcj2Bw6S9BBwUH6NpBskfTJvcynwGPAw8GfghIh4vIFpNDOzHtKwNpiIeBDYqIPl2xT+ngN8u4bPGt+jiTMzsx7XJxr5yzZs2aVYasigZiejR7319rvMfvWtZifDzNqYAwyw1JBBfPWoy5udjB51xWl7MBsHGDNrHs9FZmZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQDG7UjSaOBi4ERwCxgXEQ8XLXNAOAcYGtgHnBqRJyX1x0L7A7MAd4FjomImxqVfjMzq08jSzDnAhMiYjQwAZjYwTZ7AGsCawEbA+MlrZHX3QVsGBEfB74BXClp6dJTbWZm3dKQACNpJWAMMDkvmgyMkTSyatPdgEkRMTciZgLXArsARMRNEfFG3u5+oB+pNGRmZr1Qo0owqwFPR8QcgPz/jLy8aBTwZOH1tA62ARgHPBoRT5WQVjMz6wENa4PpKZI+B5wIbFHve0eMGNrzCerFRo4c1uwk9Bo+Fgv4WCzgY7FAGceiUQFmOrCKpAERMSc35q+clxdNA1YH7s6vFyrRSNoYuAzYMSKi3kTMmvUac+fOW2R5q55kM2fOrvs9PhYL+Fgs4GOxQDsdi/79+y1RxrwhVWQR8TwwFRibF40F7svtLEVXA/tJ6p/bZ3YCpgBI2hC4Etg5Iu5tRLrNzKz7GllFtj9wsaTjgJdI7ShIugE4LiLuAS4FNgIq3ZdPiIjH898/B5YGJkqqfOZeEfH3BqXfzMzq0LAAExEPkoJH9fJtCn/PAb7dyfs3LC91ZmbW0zyS38zMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrhQOMmZmVwgHGzMxK4QBjZmalcIAxM7NSOMCYmVkpHGDMzKwUDjBmZlYKBxgzMyuFA4yZmZXCAcbMzErhAGNmZqVwgDEzs1I4wJiZWSkcYMzMrBQOMGZmVgoHGDMzK8XARu1I0mjgYmAEMAsYFxEPV20zADgH2BqYB5waEed1tc7MzHqfRpZgzgUmRMRoYAIwsYNt9gDWBNYCNgbGS1qjhnVmZtbLNKQEI2klYAywRV40GfiZpJERMbOw6W7ApIiYC8yUdC2wC/CfXazrygCA/v37dbrBissvU89X6hMW930XZ/CyI3o4Jc3X3WOx4tAVejglzdfdY7H0ij4vKpYb/r4eTknzdXQsCssGdOczG1VFthrwdETMAYiIOZJm5OXFADMKeLLwelrepqt1XfkgwPKLCSLnfH+nGj+q7xgxYmi33rfe/j/u4ZQ0X3ePxem7HN/DKWm+7h6Lz595eg+npPm6eywO+O42PZyS5uviWHwQeLTez2xYG0yT3Q1sCjwDzGlyWszM+ooBpOByd3fe3KgAMx1YRdKAXHoZAKyclxdNA1ZnwZcplloWt64rbwO3dzPtZmbtrO6SS0VDGvkj4nlgKjA2LxoL3FfV/gJwNbCfpP6SRgI7AVNqWGdmZr1MI3uR7Q8cJOkh4KD8Gkk3SPpk3uZS4DHgYeDPwAkR8XgN68zMrJfpN2/evGanwczMWpBH8puZWSkcYMzMrBQOMGZmVgoHGDMzK4UDjJmZlcIBxszMSuEA0wSS+uX/ffzNGqRyvUlaKv/fvZku+5A8awqS1pG0XKP37xtcg1QFk4EAeWZo64ZCkF5L0qeanR7r/QrX27clrRgRLT8IsDLBMOnxKKMavX8HmAapnNySTgF+JOnW/BA264bCzeHfgSslbQAuFRZJGiZpKUlLNzstvYWkZYEtgUvylFMtq1B62Qy4NyL+3ug0+GJsgELR/ADShJ1/Az5Aeq7N8s0ouraKiDgNmAR8Ob92qRCQtDVwA/Ab4DuSNpY0qMnJarqIeBXYDngK+HyTk1OqPLHw8sAFwIaSPtboNDjANEBEzJU0GNgd2BPYELg0Il4CPgt8rZnp60s6qTe/DNhW0pmS2uURFIuQNELSR/PL44GzgCuBjwHfIE0W+9HO3t+qqku1udpoMnCWpO3zNi3ZHpPvMT8g3et/KmmLSsmmEdr2YmyC4cCdwAHAJhHx6bz8u6QcuNWgUjUm6RBSKfBu4DVgX+DnwPrAX5uWwOY6EBgl6X7gnxFxDYCk64CvAjsCDwEPNi+JjZczeCsDN5NmYP8AKcD8HjhC0h0R8WIz09iTJPWLiHmS1gKGRMRkYLKk8aTH1T8g6ZCIqH5cSo9zCaZEhTrQAfmRBY8DBwNTJC0r6RvAOxFxWTPT2dfkHOlzpEbLTwHfB35CunFcJ2lM81LXVL8GniU9XG9DSV+XtHxEPB8RPwEOiYibm5rCJomIGcDJpBnZHwAOA14B1gCuktQyz0AutE9+HbhN0vGSlouI8cDmwLuNSotnU24ASecClwP/IJ3kKwAfJuUkz4yIe5uYvD5NUv+cQ12VdHM9ApiX22baRiHXugywHrAXMIzU3nc78NeIeK+ZaWy0wrkxCOgXEe90st3lwISI+L/GprB8kj4HnAQsB5wVERcU1vUvu83SAaYkhad3bk4qml8ZEWPzuo8DLwGzIuKNZqazrygcz/WBrUk30V8ADxSrNyR9BfgPYJ12afCXtGpEPCVJwMSI2KzQ5rc5sDRwUUT8rqkJbRJJPwbWIWVArgfujoinCuv/ApwbERc2KYk9opLJyH8Pioh3C+uOIV0XF0bEPo1Kk6vISpB/6Er/8+NI7S7LSPq3vOwRYK6DS+0Kx/MCIICNgUuAUyV9QtLQvL4fcFIbBZd+wHaSniS1K5yfV70bEZeQGnjvAhreRbWZCtXTB5KeKf9TYDfgO8DRkraStEwedDmxrwcXWKh98mjgYklrVo5DRJwMnAP8Km/TkHu/SzAlkrQv8KWI+IqkM0mPib5U0rXA7yJiYnNT2DcUqjoOJjXiHwj8ETicVIoZDuwUEfc0L5XNJeks4FvAP4FvVqpdJe0M3BIRLxRzuO0gt6vcCWwFHAU8AdxPaqu6MCIObVriSpRLsqeSeg9OIvUk3BH4XETs2si0uATTw3JueoX88ilSmwCk3k4b5yqeFRxcaiNpYKE0MhgYDxwL/G+uMz8BuKldg0shJ3oJ8HFSdexdki6XtBVpBPfbsFDjb7tYntTm2Q/YNCLOiYhbgOuAayGdX01LXQlyVXJExL+TGvm3Ay4ExpJ6kDV0MLIDTM/bilQd9hnSje+JvPwPpN49N5J6PFltjpK0bf77bFI9+hvAs7nxdj9SDq3tRvEXSnYrAK9FxCMRcTSwKunmehDw7YiY3cixD80kaTtJ10j6fxHxdERcSeo19ZCkf89tEcNyoKEVOj4UqgM/AZwt6cZcYzI4Ij5P6jG3bUTcmkuxDas+dhVZD8o3uMqFPIV0kZ8dEZV6z5OBj0TEbk1KYp8iaU3gSNIxfZLUUeJhSV8i5cz/AoyIiM2bmMymKPQaWxW4ClgGGEnqinx13mZ4RLzcxGQ2XO41tRXwUWAqcElEPJHHgGwEDAKOiYi7GtGLqpEk/ZU0Fqw/6XzYCDi5GVPEVDjAlCAPAvwLaYzGl4FZpB4cDwDL5zExVoPc7fZE0vxRjwA3keqVVweGADMi4uVKL7PmpbQ5JJ0BvBcR31OaiuhU0nm2f0T8rbmpaw5J25AGlm5CanP5TUScpzQP2VsR8U6rtUdJ2gH4TkRsnV+PAE4DZgOHNyuQtlWVQpkKxdTdgC+RAswEUmC5G7iG1ODv4FKDQt3454DRwOmkcUSfJjXsrws8Usmht1Nw0YKZpNcjzWIwASAiJkTEMNKA3hOal8KmO4FUbfodUq+psZKuAj5fGQvTSsElmwa8J2nt3EV5FqmUv3ozS2kOMD2kcIM7itQteTjwQ+B3wEeAcaSpKawGhbrxo4CfRMRFpC7f15NKMzuyoDqyrRRujt8idXg4pmr9V8mTf7ZL20uFpO2A2RFxXUTcQAowtwErkxr7W9WjpLF1RwGfzR08TmZBZ4am3OsdYHpQHucymzSo6zjSCb0hsCLwZES81cTk9SmS+uWb47+A9SUNjog5EXEVcAvwq4h4s90a9osi4kBSsN1K0mOStiysm1P8v408BPSTtK2koRHxGmlW6ccj4trmJq3nVEr4kobka2AOKcMxkzT2aU/gzoi4GJo3y3jbXpxliIj7SCWWHwPP5bl/hgCrRcS0Zqatr4mIefnm+Cdge2AHSRtJ2htYKyKuz9u1TCNtV1SY8VfS+yWtFhE3R8SHgJ8BN0q6pnkpbI5CleEqpJz8rcCuwJ65XepnpK7JLdPTsFDC/xmpZ+o5wM6kWpMdI2Iv0ozaTf3OLXGwe5mzgE9ExKk5B/5fpGoM64aIuAK4GDiUNKnlv5Muorar/iFX8Uj6Aand5X5J50n6YkScCbyP3AW+VW6ktci96UYDk3Om5CTSHGwbkGoTrsol35bIkEjaKP//eWAt4BRSye1zwBnAV/IMBUBzv7N7kZUkF2E/TRo9e1Kz09MXqWpuJWAVYFoseDpoS3UzXZxCt+QPkR4ithmwLGlSy68BB0TEjU1MYsPlDMbgXFW6HGmw6d6R56aTtExEvF7Yvs+fL5I+SMrEPgmsRAqqv8/3m8+SqkzfDxwUEW82L6WJA0yJctF9QCsM5mqmdu2C3BFJRwCjI+JbhWWHAwOj/WaQPgp4h9SQPYs039jxEfFkHkO1J3BjRPy5eansWUqPv94B+DfStElLAYdFxNS8fjgwMo8Xa3pAbalpEnqbnPt2cKnB4sYlVIJLYeT6+4ENI+K3DU1k73AL8CVJI3JXVEg3mQ81L0lN8wqwC2m82STSlDjXS5pKqhq7gzQmqGXkUsmVku4glWK/CHwrf+frI80S/XLetumltbapp7Xeq6oqbKvOtitcMGcBpT+Nr5f6OzADmC7plNyIvTtpjrZ2a3uZSGrYfoQ09mUz0uSW/wV8NiIOjIjXWumYVDo0RMRTkR5UeBbpIWobAidI+kAz01etZQ689WmfkbSu0jTj/w8WvVEWumV+AejfLqPUCwN4PyRpQ9JjHsaRnomzNjAU+F5EPN0bqkQaodBrbEBEvBwRx5Gm4r+R9JTTzUjzsQG9IyffUwoZsUqg+RtwJmlqqtsi4tni+mZzFZk1ldKU6sNJ08GsTZr1df5NQdKwiJhdaMf6PqluveXlkt0cScNIT0RdCXhG0mXALyNix+L2rXQjrdG3JK1MatT+r4g4JJeAjyYNyG1ZxUCTq5BvLPaq7C0zFbgEY00V6aFrt5Hq058B9pd0TO4VBHCapFEwvzH7jkourdUVbhKHkb73msBlpDEeEyTtUuyO2g5yKW2e0qSWu5Oef7MVMDevuykiPl9p9G4FiyuNFALNwJwZeX+ezaBXcICxpikU82eTnl2xDalHkEhP5LuBNLX6tLztHNL0Fy2vUkWYqwb/SGrcr7Q77AK8QOoC31azQxRKaQeTAu9bpKqhqcBHJR2lFnrGSx3tk5USfq9qn2yZH8L6nsKF81HSIMEXI2KypLtIz84RqetpZfuzm5LQJijcSM8gtUu9KwngroiYCRxaKb20S9sLzM+UDCF1dhhJmodt57z6u8DzLTYs4DOSXiE9OGwYcFP1751LL+/1xvZJBxhrisrYFkn7AF8hlU4GSroFOD9PblnZtqWmVu9KoTv2dsAngO8BO5GqhNaVdC+pRFN5UmVbBBeYnyl5S9KLwEWkRx8/IWlzYAypN1VLnDOt0D7pKjJruELj9RDSlOp7kAbMzSLl1i+T9PXK9n39RlGvQsDYFvhRRPweOIQ0n9bHSW0wff4GWg8tPA/bkIg4hzQtzj6Sfkc6PidGetbLgFY4Nq3QPumR/NY0So+vXY40SO6XEfFJSQeRqgPGR8SdTU1gE+VG7MoDo74baSJVJK0ErBoR97ZCLr0WhRLdqqRAsjTpIWuHSlqD1Ivsn7ktryVUtb0sR6pC3ozUPX05YDCpSnnPHHwPBs6NiLeblOQOuYrMmulC0kwHe5IbsUmz4c5o5+CSPUp6/O1mwDerRmo/D+1TsiuU6M4m5eg3II3/gfTAtWci4u1WCrit0j7pEow1RVUObRPgP0m9pXYCvhkRt7dT43VnJK1PmsBQpCrtY3pbNUgjKM0gfGxEbCfpduCIiPhLno/szxFxW5OT2GM6a58kZcLOj4gXCtv26qDqNhhriqqL4gHSQMJ3gUk5uPRr5+DSV0ZqN9BSwB2SzgAiB5fVgH2Bh5ubtJ7Tau2TDjDWMJ3dFCPiZWBCRBwfEWflxf3b8CY6X/VI7UhT8V9avb6VVY1MvxX4KClHf7bSrMEnAZdFxDNqkWcDFX7XI4CbgRHA6hGxJ2kqnH5ANCl5dXMbjDVMZzdFLXjWyaCIeLfS/bLR6WuWxVVzVI3Ufk9tNJN0zsm/j/TAuW+ROj2sRnrA1hDgsYg4IW/eaqXdlmifdAnGSifpo5K2yjeLyrL5pZPKTTQi3s2Lfq1eNitsWfr6SO0y5VLJ26QqoqOBJyNic9Ijyb9K6lE2f/qYpiW0h+Vz4pk8oPZu4LOSTgZOB87P2/SJe3efSKT1eXsD3ySNWVgPFp0VVgtmDd4VeKCNGrI9k3SVQnXX4DyR4+GknlSHAUTEbRHxfOQnNrZaW10rtU+6F5k1hKRDgS2AQaS2hNsj4vG8bn5vMUl3Alu2QxVZLtF9nlTfvjYwNiL+WFi/UFWhpJuBPdsl+Er6KakN4nTSANNTSNVFR0VES5XiFldNWr0uB+C5faHU5hKMlaqQG18beJBU5bEDcJikLSWNLASX40lTf7R8cIHWGKldFkkrAB8hzVrwQ2Ae8GfSc1+2bGLSSlFL+2R+PSx3+uj1wQUcYKxkeQT2jsB6EXFERGxP6na7Wf5/DICk5YFPkuuYW508k/QiqtrlXoyIbUiN+38nZU72BY4Erq7evq/qZvvkBxuczG5zLzJrhKVIj7WtzCN1p6QDSXXqtwFExEuS9s517i2vVUZq96TCMTmANP3LX4E3gZnAhyPiL6RMSa8fYFiHvYE1gdGSbomIv1d1UZ9XGHhZaZ98pqkproPbYKx0uZrnGlLO8wxSF9NfkAYOTqxcQM1MYyO10kjtMuTODF8lBZYNgM8CywBnRsSRTUxaKVq5fdIBxnpcB42Sg0g58itJffsfAlaIiC80KYlNU8iVDgH+D/gicB4pp748MIA08edFzUtl76A0sefbpCdWbkPqRXVHqwRdLZjE8xekSU1Hkx6g9gzwW+C+3FW50j75TET8omkJ7gZXkVlpJB1Jmvn1E6Rp59eR9HlgGvBy3qatSi+LGaldnEm6z4zULkPlxhsRz+dFV0maUuia24/U6N+nVbVPbgwgaWNgIrA56Ry5qdA+uVOz0tpdbuS3HqUFz0z/LOmC+D9gLRZM/XJ/RDwKvAhptHbTEttcF5K6325PHx6pXYbqMR6qmvS0r4wBqdEi7ZPAgaT51ea3TwJ9sn3SAcZ6VOHiP4A0QG4A8Nd84XwIOETS0q1QxdFdrTRSe0nV0xNM0geUnvLZSu4EPibpe8AcScuQes7dGBFvVgadFtvl+pK2OImtcST1y20ufwfWAU4gTfNB/n9YZQR2u2qlkdpLoo5pcirH4kz6+DQ5HQTUZ0jd1MeRes1dBHwgIiZC3y/hO8BYjyiM65iX++w/TCrB3A68ktteNgaOKW7fLjr7vtHeM0m37TQ5ko6UdCLwa2CZiFgHOJSUCds1b9PnZ4h2gLGeMgxA0g8kfZnULfly4DPAZFKV2QmVYn+7VZG16kjt7soDC4cD55BurDfDgtKKpGH5dWWSz+/n7fqsdmyfdDdlW2JKz0o/DHgd2AXYLCKeK6wbDjwcvex54Y2QB1KuDvwpTw3T1bxTfwD26EuD6borB5FLgDVIXdf/RirNvSLpv4BT8kwGhwPLRcTxzUttz5F0BfATYCXS3HK7S/owqarslFaqQnYJxpZYpOfEX0fq/TIEWFPSsoV1K0R+ZnoTk9ks3ZlJuqWDS7tOk9OO7ZMuwViPkXQIMJR0U70bOJYUdFaM9ES+ttTKI7WXRNU0OU9I+giFaXIiYkYrDKrsYODxzsDxwB/z/xuQqgo/lauQ+/x3rnCAsR6n9NTFU4F1geeAAyLiyerxDK2uHUZq16sdp8mRtGxEvCrpB8C/SKW1o4CdgReA14ArI+LqVht47ABj3Va4WXyZ1ENsa9KI/Sl5/arAOxHxfLsFl4o8UvvoDkZq9weOiIjKSO1LgJ1a6eZSrR2nyWn39km3wVi35JvFHElLAyeSnpveH7hE0p8lbRoRT1Wm+2jH4JK19Ejteixmmpw9gRtJU8C01DQ57d4+6QBj3VK4WYwHriBNYvlsRFSea3GrpE80I229TEuP1O6mtpomJyJuAX5EmqXhYmCipDUl/YTUAaTTbux9nQOMdZukpYAngQmkcQrX5FUXkKp//tqstDVLu43Urle7TpMTEWdHxEmkRw+8RRobtibwA2jN7wyeTdm6Kd8o3pI0KSLelfQkMDAPoDuMBaOR27XtxTNJd6CTaXJG0mLT5HTRPrl3u7RPupHf6lK4cD5IGr3/MeAmUoPtr0jtCo9FxLdapRdQrQq9xj4L/Bg4idT9dBzpefIrRMSsNjwuixtYWt2FdwAwty8fn0JnhqWBe4DdSM9C+hBwP/DdiPhTM9PYKC1ZLLPyFHLck4BvA6cAO0fEb0ljYL5BmhYGUqNt2wjPJN2hdpsmx+2TCzjAWM0q9cSSjiA1yv6cdPH8RtJywIakC+k9aL+eY+04UntxJH1U0la52rSybH6mo3IjjjQ5KsCvc8m4z3P7ZOIAYzXL1T+DSIHkJ8B3gMsi4lVgM+Dgws2ibcgzSXemLafJqbRPktqVXiYFmmL75M15u5a//7b8F7SelW+gU0jdLtePiNPyqkPz8ra4cKp4JukORMT3gD+RGrjPkLSXpA/ldfNym1WlyvUwco+qvkoLptf/gKTRwDa5JHMXcBppav7bIuLvrdKZoStu5LcuFRqv/w3YA/gf0uDKR4BbgTHAyhGxfROT2RTtPlK7M+08TY6k35JKsVsBJ0fEZbnk/wHS93yvlXuOFbVbTtO6oXAh7APcExE3kcZ2vE5qa7iXNHiwJR6SVI92H6ndmRxcdgTWi4gjcubjTFJV6pmkTAl5mpxPksfA9FVun+yYA4wtVqGufHNgReBtgIj4Z0TsBxwZERMjYkZe3lbjOqC9R2p3oW2myXH7ZMccYKxTVWMUNgY2Bw6WtE5hipN3mpbAXqRdR2p3oa2myXH75KLcBmOdKtSjH0rKid5H6nq7Gem5JhdExLTmpbB5uhip3ZYzSXcwaHIQ6dkuV5Kqix4iVRl+oUlJ7HFun1y8toqmVrtKLxdJHyDlOh+IiKcjYh/SyPQvk+rS2448k/RiSTpS0omkXlPLRMQ6pFz80SyYQqgl2urcPrl4DjDWoUJO9FvAdZGeODgsr7sDOJj00KS2K/Z7pPaick5+Xp4mZyfS817WAvrndrz7I+JR4EVojbY6t092ra1uDNYtU4HVYP4z1JF0NLBfRDyWl7dVDh08Urtau02T4/bJ2jjAWFfuAVaRdIGkHSSNIdU1j4f2K72AR2p3pA2nyamUXg4F/gb8G/AY8BvgWEmjmpe03qNtLgDrnoh4GtiXdPGcQepmek5EPNwujdcVHqm9qHacJsftk7Xz82CsSxHxkKSTIuI/JA2sDBYDWqK6o1ax8EzSlZHaw/JI7aHkkdp5m360x/EZBrwq6QfAv0hVhWsCO5O6ar/GwtPk9Pl2iM7aJyNidkTcIelg0nN/2vZ5SBXupmxWg0J31COAUcDPSM+/2YQUTNYB7m6nwXTtPk1Onqlg94gYW1h2NGn2gj2al7Lew1VkZjXwSO1FeZoct092xSUYszpI2hnYAVg1IjbPy/4ITIiIKe1YJSLpENLD5vYG7gaOJQWdFSNiz2amrWy5LW5X4GukmaPvjIhJ7XgedMQBxmwxPFK7dpLeD5wKrAs8BxwQEU+2+s1WC57MOb99snpWg3blAGNWA0k/A26PiF9KWpvU9vAm8A9SQ++MVmnE7oqnybFaOcCYdaKQM92cNCvylRHx34X1g9ttMF3hmCxNaoPYjTTX2IeA+4HvRsSfmplG6z3avhHKrCMeqd0xT5Nj9XCAMeuYR2p3wtPkWK0cYMyqeKR25zxNjtXDJ4FZFc8kvShPk2Pd4alizDo3FdgdFplJev5I7Xa5kXqaHOsO9yIz64SkVUjzaT0CXAs8RXq42JfbabJPT5Nj3dUWxXuz7vBM0omnybHucoAxW4yIeAg4KSLWAr4ZEZPyqrYq+ucAMgX4EbB+RJyWVx2al7dNe5TVzlVkZtYhT5NjS8o5DjPrUKEKcB/gnoi4Cfg6aXr+dYB7ST3tir3MzOZzCcbMFuFpcqwnuJuymS2kk2ly3i/pIeDBiJjj4GK1cBWZmVXzNDnWIxxgzGw+T5NjPckBxszm8zQ51pN8gphZR6YCq8Ei0+TsFxGP5eVtMdDUus+N/GbWkXuAIyRdwIJpcvYgVZHRTjMZWPe5m7KZdSjPmrwr8DXgT8CdETHJwcVq5QBjZp0qjIcZGBHvFZc1O23W+znAmJlZKdzIb2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCg+0NOuCpCeA9wNzCotHR8SMJfi8fSPi5iVPnVnv5QBjVpvte0tAKI5JMevNHGDMukHScqRZhbcB5gIXAsdHxBxJHwEmAesD84CbgAMi4mVJlwKjgOskzQFOAO4CLouIVQuf/wS5lCNpPLAu8BawA3C4pKsXs/81gfOBDYB3gf+NiN3KPB5mHXEbjFn3XAS8B6xJel7KlsC+eV0/4BRgZeBjpEkjxwNExF7ANFKJaGhEnFbj/nYEpgDDgcu72P+JwO+B5YFVgZ925wuaLSmXYMxqc62kSrXUnaSnPA6PiDeB1yWdRXq08MSIeAR4JG87U9KZwPFLuP87I+JaAEnLkkouHe6fVGpZHVg5Ip4Cbl/CfZt1iwOMWW12qrTBSPoUsBXwjKTK+v7A9Lz+/cDZwKbAsLzupSXc//TC36sDgzrbP+l5LScCd0l6CTgjIi5Ywv2b1c0Bxqx+04G3gRU7aWw/mdT2sl5EvChpJ+BnhfXVEwC+Dryv8kLSAGBk1TbF9yx2/xHxLLBf/qxNgJsl3ZZLVmYN4zYYszpFxDOkNo4zJC0rqb+kj0j6XN5kGPAa8IqkVYDvVn3Ec8CHC68fApaStK2kQcAPgSHd3b+kXSRVOgy8RApOnl7fGs4Bxqx7xgGDgX+SbuJTgA/mdT8CxgCvANcD11S99xTgh5JelnRkRLwCfAc4D3iaVKJ5agn2vyHwF0mvAb8BDqk8hdKskTxdv5mZlcIlGDMzK4UDjJmZlcIBxszMSuEAY2ZmpXCAMTOzUjjAmJlZKRxgzMysFA4wZmZWCgcYMzMrxf8HqD6ZubL2H9kAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -3361,10 +3361,10 @@
    "id": "176c1d98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.321633Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.320981Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.324481Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.323844Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.332908Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.332047Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.335555Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.335167Z"
     }
    },
    "outputs": [],
@@ -3379,10 +3379,10 @@
    "id": "c33dc4f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.327404Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.326873Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.335166Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.334572Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.338292Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.337556Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.343359Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.342948Z"
     }
    },
    "outputs": [],
@@ -3397,10 +3397,10 @@
    "id": "313c6906",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.338818Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.337612Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.343207Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.342614Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.346569Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.345850Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.350253Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.349873Z"
     }
    },
    "outputs": [
@@ -3427,10 +3427,10 @@
    "id": "460daed6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.346202Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.345868Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.460279Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.459706Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.353033Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.352279Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.447966Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.447516Z"
     }
    },
    "outputs": [
@@ -3463,10 +3463,10 @@
    "id": "9874b4b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.464652Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.463377Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.468637Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.468018Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.451082Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.450335Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.453752Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.453364Z"
     }
    },
    "outputs": [],
@@ -3489,10 +3489,10 @@
    "id": "fae59295",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.472758Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.471571Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.479419Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.478852Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.456636Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.455911Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.461727Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.461296Z"
     }
    },
    "outputs": [
@@ -3526,10 +3526,10 @@
    "id": "4778b695-9ec8-4d9f-a1dd-26d749b43a95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.482634Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.482165Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.488380Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.487806Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.464492Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.463775Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.468483Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.468066Z"
     }
    },
    "outputs": [
@@ -3559,10 +3559,10 @@
    "id": "5b0ce173",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.491540Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.491070Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.495135Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.494583Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.471280Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.470555Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.473616Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.473227Z"
     }
    },
    "outputs": [],
@@ -3587,10 +3587,10 @@
    "id": "29683916-4ef7-474a-80ac-11a5d210b6fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.498533Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.498065Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.502076Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.501499Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.476456Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.475744Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.478896Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.478513Z"
     }
    },
    "outputs": [],
@@ -3609,10 +3609,10 @@
    "id": "b0d608dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.505187Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.504747Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.513835Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.513282Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.481638Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.480931Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.489000Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.488488Z"
     }
    },
    "outputs": [
@@ -3708,10 +3708,10 @@
    "id": "9ff2919e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.517021Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.516584Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.521565Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.520984Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.491517Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.491143Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.495191Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.494742Z"
     }
    },
    "outputs": [],
@@ -3727,10 +3727,10 @@
    "id": "cc733746",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.524674Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.524191Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.642849Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.642210Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.498019Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.497198Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.595907Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.595473Z"
     },
     "tags": []
    },
@@ -3776,10 +3776,10 @@
    "id": "7bdf2192",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.646543Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.646027Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.792590Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.791973Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.599310Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.598259Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.719337Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.718851Z"
     }
    },
    "outputs": [
@@ -3822,10 +3822,10 @@
    "id": "6134ddb1-994f-42ee-8a68-7111540b6481",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.795874Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.795530Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.801931Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.801315Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.722494Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.721621Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.727254Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.726863Z"
     }
    },
    "outputs": [
@@ -3853,10 +3853,10 @@
    "id": "2d5a9368-bfaf-4348-b140-13e6d725f59c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.804932Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.804362Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.808788Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.808196Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.730091Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.729239Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.734039Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.733667Z"
     }
    },
    "outputs": [
@@ -3882,10 +3882,10 @@
    "id": "cc984a01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.811506Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.811299Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.814082Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.813470Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.736883Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.736022Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.739275Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.738890Z"
     }
    },
    "outputs": [],
@@ -3910,10 +3910,10 @@
    "id": "f07d0334",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.816717Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.816510Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.822907Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.822316Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.742161Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.741324Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.747783Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.747345Z"
     },
     "scrolled": true
    },
@@ -3931,10 +3931,10 @@
    "id": "35f93d4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.825413Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.825207Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.838616Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.838015Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.750390Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.750161Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.763961Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.763522Z"
     }
    },
    "outputs": [
@@ -4002,10 +4002,10 @@
    "id": "d5ae2981",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.841204Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.840998Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.846320Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.845729Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.766398Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.766046Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.771663Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.771252Z"
     }
    },
    "outputs": [
@@ -4065,10 +4065,10 @@
    "id": "9d5e19bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.849278Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.849073Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.853316Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.852712Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.774499Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.773652Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.778056Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.777631Z"
     }
    },
    "outputs": [],
@@ -4088,10 +4088,10 @@
    "id": "2eab2fb8-ee9e-4a4e-9d2e-7629f9c56cb9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.855848Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.855642Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.859960Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.859382Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.780356Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.780011Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.784945Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.784536Z"
     }
    },
    "outputs": [
@@ -4151,10 +4151,10 @@
    "id": "2b2da9ab-de61-44f5-91f1-a897e8f7a962",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.862938Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.862724Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.865992Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.865358Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.787246Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.786958Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.790365Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.789915Z"
     }
    },
    "outputs": [],
@@ -4168,10 +4168,10 @@
    "id": "773682ad-cda8-42ec-9275-dc611004d913",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.868518Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.868314Z",
-     "iopub.status.idle": "2022-11-17T11:42:50.874530Z",
-     "shell.execute_reply": "2022-11-17T11:42:50.873943Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.793299Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.792432Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.799036Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.798613Z"
     }
    },
    "outputs": [
@@ -4398,28 +4398,28 @@
    "id": "7333e449-4e2a-42aa-b728-3f36d205ed1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:50.877582Z",
-     "iopub.status.busy": "2022-11-17T11:42:50.877378Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.057631Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.056956Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.801436Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.801093Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.958481Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.958032Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'ResponseMetadata': {'RequestId': 'lal06oln-5jl0q2-6cg',\n",
-       "  'HostId': 'lal06oln-5jl0q2-6cg',\n",
+       "{'ResponseMetadata': {'RequestId': 'lamxrcrk-4k1dw5-2it',\n",
+       "  'HostId': 'lamxrcrk-4k1dw5-2it',\n",
        "  'HTTPStatusCode': 200,\n",
-       "  'HTTPHeaders': {'x-amz-request-id': 'lal06oln-5jl0q2-6cg',\n",
-       "   'x-amz-id-2': 'lal06oln-5jl0q2-6cg',\n",
+       "  'HTTPHeaders': {'x-amz-request-id': 'lamxrcrk-4k1dw5-2it',\n",
+       "   'x-amz-id-2': 'lamxrcrk-4k1dw5-2it',\n",
        "   'access-control-allow-origin': '*',\n",
        "   'access-control-allow-credentials': 'true',\n",
        "   'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',\n",
        "   'access-control-allow-headers': 'Content-Type,Content-MD5,Authorization,X-Amz-User-Agent,X-Amz-Date,ETag,X-Amz-Content-Sha256',\n",
        "   'access-control-expose-headers': 'ETag,X-Amz-Version-Id',\n",
        "   'etag': '\"60214a1c84c410739db1ba5301838194\"',\n",
-       "   'date': 'Thu, 17 Nov 2022 11:42:51 GMT',\n",
+       "   'date': 'Fri, 18 Nov 2022 20:10:28 GMT',\n",
        "   'keep-alive': 'timeout=5',\n",
        "   'content-length': '0',\n",
        "   'set-cookie': '1a4aa612fe797ac8466d7ee00e5520d5=a26d7dd2bae782e2ad6181b7887b5ff1; path=/; HttpOnly; Secure; SameSite=None'},\n",
@@ -4446,10 +4446,10 @@
    "id": "618842b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.060502Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.060274Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.092438Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.091822Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.961544Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.960653Z",
+     "iopub.status.idle": "2022-11-18T20:10:28.991315Z",
+     "shell.execute_reply": "2022-11-18T20:10:28.990879Z"
     }
    },
    "outputs": [],
@@ -4467,10 +4467,10 @@
    "id": "457f28ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.095448Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.095227Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.177396Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.176785Z"
+     "iopub.execute_input": "2022-11-18T20:10:28.993683Z",
+     "iopub.status.busy": "2022-11-18T20:10:28.993452Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.073740Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.073289Z"
     },
     "scrolled": true
    },
@@ -4510,10 +4510,10 @@
    "id": "0f1495a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.180692Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.180339Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.188043Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.187496Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.076224Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.075872Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.081659Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.081239Z"
     }
    },
    "outputs": [
@@ -4549,10 +4549,10 @@
    "id": "624b3504",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.191903Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.190754Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.196626Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.196077Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.083927Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.083626Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.088308Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.087777Z"
     }
    },
    "outputs": [],
@@ -4571,10 +4571,10 @@
    "id": "45cd6a78-361c-444f-8065-4127f2e29313",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.199732Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.199284Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.208277Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.207530Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.090155Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.090001Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.097064Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.096656Z"
     }
    },
    "outputs": [
@@ -4873,10 +4873,10 @@
    "id": "8b937135-f983-4d6c-961e-f9c7158d108c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.213069Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.212736Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.217119Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.216572Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.098879Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.098727Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.102193Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.101781Z"
     }
    },
    "outputs": [],
@@ -4890,10 +4890,10 @@
    "id": "63f382a4-5826-4d65-aa9f-5f3b56f1aad9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.220814Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.219651Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.228607Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.228066Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.104012Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.103863Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.109898Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.109467Z"
     }
    },
    "outputs": [
@@ -5003,28 +5003,28 @@
    "id": "2c67ed79-0555-4f0d-9557-3e6d335baeac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.232374Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.231214Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.459891Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.459271Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.111821Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.111668Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.291627Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.291170Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'ResponseMetadata': {'RequestId': 'lal06ovj-bf6gas-n1w',\n",
-       "  'HostId': 'lal06ovj-bf6gas-n1w',\n",
+       "{'ResponseMetadata': {'RequestId': 'lamxrd05-9o3x78-8hm',\n",
+       "  'HostId': 'lamxrd05-9o3x78-8hm',\n",
        "  'HTTPStatusCode': 200,\n",
-       "  'HTTPHeaders': {'x-amz-request-id': 'lal06ovj-bf6gas-n1w',\n",
-       "   'x-amz-id-2': 'lal06ovj-bf6gas-n1w',\n",
+       "  'HTTPHeaders': {'x-amz-request-id': 'lamxrd05-9o3x78-8hm',\n",
+       "   'x-amz-id-2': 'lamxrd05-9o3x78-8hm',\n",
        "   'access-control-allow-origin': '*',\n",
        "   'access-control-allow-credentials': 'true',\n",
        "   'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',\n",
        "   'access-control-allow-headers': 'Content-Type,Content-MD5,Authorization,X-Amz-User-Agent,X-Amz-Date,ETag,X-Amz-Content-Sha256',\n",
        "   'access-control-expose-headers': 'ETag,X-Amz-Version-Id',\n",
        "   'etag': '\"19e2e3b6fd0e764da7b80d876ed130be\"',\n",
-       "   'date': 'Thu, 17 Nov 2022 11:42:51 GMT',\n",
+       "   'date': 'Fri, 18 Nov 2022 20:10:29 GMT',\n",
        "   'keep-alive': 'timeout=5',\n",
        "   'content-length': '0',\n",
        "   'set-cookie': '1a4aa612fe797ac8466d7ee00e5520d5=a26d7dd2bae782e2ad6181b7887b5ff1; path=/; HttpOnly; Secure; SameSite=None'},\n",
@@ -5057,10 +5057,10 @@
    "id": "4cdafdae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.463412Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.463051Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.472205Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.471637Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.294011Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.293605Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.300314Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.299852Z"
     },
     "tags": []
    },
@@ -5410,10 +5410,10 @@
    "id": "894941f7-9815-44af-867a-9e206502cd7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.475507Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.475043Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.492150Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.491574Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.302387Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.302229Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.314554Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.314075Z"
     }
    },
    "outputs": [
@@ -5656,10 +5656,10 @@
    "id": "4fd9e422-eaf1-4c80-9375-5d71ac985171",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.495298Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.494970Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.509281Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.508794Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.316661Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.316499Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.328747Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.328261Z"
     }
    },
    "outputs": [
@@ -5695,10 +5695,10 @@
    "id": "ecd03940-1b27-4472-ae97-469a4ad8a25a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.512900Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.512387Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.515613Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.514986Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.331260Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.331057Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.333504Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.333045Z"
     }
    },
    "outputs": [],
@@ -5712,10 +5712,10 @@
    "id": "adfdfb1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-11-17T11:42:51.518297Z",
-     "iopub.status.busy": "2022-11-17T11:42:51.518081Z",
-     "iopub.status.idle": "2022-11-17T11:42:51.881133Z",
-     "shell.execute_reply": "2022-11-17T11:42:51.880510Z"
+     "iopub.execute_input": "2022-11-18T20:10:29.335423Z",
+     "iopub.status.busy": "2022-11-18T20:10:29.335272Z",
+     "iopub.status.idle": "2022-11-18T20:10:29.700679Z",
+     "shell.execute_reply": "2022-11-18T20:10:29.700110Z"
     }
    },
    "outputs": [],

--- a/process_pr.py
+++ b/process_pr.py
@@ -139,7 +139,7 @@ def parse_pr_with_mi(pull_request: GithubPullRequest):
     return pr
 
 @github_handler
-def get_mi_parsed_pr(repo, pr_id, gh_token):
+def get_mi_parsed_pr(repo, pr_id, gh_token, gh):
     prs = repo.get_pull(int(pr_id))
     pr = parse_pr_with_mi(prs)
     return pr


### PR DESCRIPTION
Resolves https://github.com/redhat-et/time-to-merge-tool/issues/24

Modified the workflow file to use the user provided Github token instead of the automatically generated token. This drastically **increases the API limit from 1000 to 5000**.

Also modified the `github_handling` logic:

- To log the API limit left after collecting each PR
- Optimize the object instantiation across the notebook to make fewer API calls to Github

Like seen in this workflow https://github.com/oindrillac/time-to-merge-tool/actions/runs/3499848007/jobs/5861864319, we increased the API limit we started with to 5000 and as a result, we collected all PRs (250) in one go. Moving forward we should be able to collect ~600 PRs without getting rate limited.

<img width="958" alt="Screenshot 2022-11-18 at 4 13 05 PM" src="https://user-images.githubusercontent.com/32435206/202803396-2a046520-60de-410d-90c3-a5016fce94b2.png">

Note: The model training step fails currently. Will investigate that here https://github.com/redhat-et/time-to-merge-tool/issues/23
